### PR TITLE
fix(a11y): avoid skipping heading levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1032,9 +1032,9 @@
       }
     },
     "@edx/frontend-learner-portal-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-learner-portal-base/-/frontend-learner-portal-base-1.0.1.tgz",
-      "integrity": "sha512-eN/LG8CwZBA38iPS1Vd9jyFF1aB1GGjdljbn/8aM/z/mvY5jfed4UV/xzKnU03fJ2lTgC58vz2yPRfoXrCQ5Vw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-learner-portal-base/-/frontend-learner-portal-base-1.0.2.tgz",
+      "integrity": "sha512-LUuq0wDNr15l1Ijsl1WdheJDkWCJ2X5V62KxCLxrFiBsDA0zkU8QSWNBgJgph+DEGgRQSybHFjuqm0GtQw9ZFQ==",
       "requires": {
         "@edx/frontend-component-footer": "^3.0.4",
         "@edx/frontend-component-site-header": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@edx/frontend-component-footer": "^3.0.4",
     "@edx/frontend-component-site-header": "^2.5.0",
     "@edx/frontend-i18n": "^2.1.1",
-    "@edx/frontend-learner-portal-base": "^1.0.1",
+    "@edx/frontend-learner-portal-base": "^1.0.2",
     "@edx/frontend-logging": "^2.0.1",
     "@edx/gatsby-source-portal-designer": "^1.0.1",
     "@edx/paragon": "^7.1.5",

--- a/src/components/dashboard/main-content/DashboardMainContent.jsx
+++ b/src/components/dashboard/main-content/DashboardMainContent.jsx
@@ -9,7 +9,7 @@ const DashboardMainContent = () => {
   const { pageContext: { enterpriseName } } = useContext(AppContext);
   return (
     <CourseEnrollments sidebarComponent={<DashboardSidebar />}>
-      <h3>Browse courses</h3>
+      <h2 className="h3">Browse courses</h2>
       <p>
         You are not enrolled in any courses sponsored by {enterpriseName}.
         To start taking a course, browse the catalog below.

--- a/src/components/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/dashboard/sidebar/DashboardSidebar.jsx
@@ -65,7 +65,11 @@ class DashboardSidebar extends React.Component {
     return (
       <>
         {isFeatureEnabled('enterprise_offers') && (
-          <SidebarBlock title={`Learning Benefits from ${enterpriseName}`} className="mb-5">
+          <SidebarBlock
+            title={`Learning Benefits from ${enterpriseName}`}
+            titleOptions={{ tag: 'h3', className: 'h4' }}
+            className="mb-5"
+          >
             {isOffersLoading && (
               <div className="mb-5">
                 <LoadingSpinner screenReaderText={`loading learning benefits for ${enterpriseName}`} />
@@ -74,7 +78,11 @@ class DashboardSidebar extends React.Component {
             {this.renderOffers(offers)}
           </SidebarBlock>
         )}
-        <SidebarBlock title="Need help?" className="mb-5">
+        <SidebarBlock
+          title="Need help?"
+          titleOptions={{ tag: 'h3', className: 'h4' }}
+          className="mb-5"
+        >
           <p>
             For technical support, visit the
             {' '}


### PR DESCRIPTION
This PR ensures enterprise learner portal homepage doesn't skip heading levels. This relies on this update in `frontend-learner-portal-base` (https://github.com/edx/frontend-learner-portal-base/pull/4), so once that update is published to NPM, will need to version bump the package here as well.