### PR TITLE
fix: upgrade to Node 12 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
-node_js:
-  - 8.9.3
-cache:
-  directories:
-    - "~/.npm"
+node_js: 12
 before_script:
   - npm i -g gatsby
 script:


### PR DESCRIPTION
As part of the upgrade efforts to Node 12, this PR updates this repo from Node 8 to 12. Once this PR lands, we can update the column for this repo with a 🍑 😄- https://openedx.atlassian.net/wiki/spaces/FEDX/pages/931561855/Frontend+Repos.