### PR TITLE
Add NotFoundPage component

### DIFF
--- a/src/components/NotFoundPage/index.jsx
+++ b/src/components/NotFoundPage/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+const NotFoundPage = () => (
+  <div className="container-fluid mt-3">
+    <Helmet title="Page Not Found" />
+    <div className="text-center py-5">
+      <h1>404</h1>
+      <p className="lead">Oops, sorry we can&apos;t find that page!</p>
+      <p>Either something went wrong or the page doesn&apos;t exist anymore.</p>
+    </div>
+  </div>
+);
+
+export default NotFoundPage;

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -3,6 +3,7 @@ import { Switch } from 'react-router-dom';
 import { AppProvider, PageRoute } from '@edx/frontend-platform/react';
 
 import { DashboardPage } from '../dashboard';
+import NotFoundPage from '../NotFoundPage';
 
 import store from '../../store';
 
@@ -13,6 +14,7 @@ export default function App() {
     <AppProvider store={store}>
       <Switch>
         <PageRoute path="/:enterpriseSlug" component={DashboardPage} />
+        <PageRoute path="*" component={NotFoundPage} />
       </Switch>
     </AppProvider>
   );

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -4,6 +4,7 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { LoadingSpinner } from '../loading-spinner';
+import NotFoundPage from '../NotFoundPage';
 
 import { useEnterpriseCustomerConfig } from './data/hooks';
 
@@ -12,6 +13,12 @@ export default function EnterprisePage({ children }) {
 
   const user = getAuthenticatedUser();
   const { username } = user;
+
+  // We explicitly set enterpriseConfig to null if there is no configuration, the learner portal is
+  // not enabled, or there was an error fetching the configuration. In all these cases, we want to 404.
+  if (enterpriseConfig === null) {
+    return <NotFoundPage />;
+  }
 
   if (!enterpriseConfig || !enterpriseConfig.name) {
     return (

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -5,31 +5,20 @@ import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import { fetchEntepriseCustomerConfig } from './service';
 
-const initialConfig = {
-  name: undefined,
-  slug: undefined,
-  uuid: undefined,
-  contactEmail: undefined,
-  branding: {
-    logoUrl: undefined,
-    banner: {
-      borderColor: '#007D88',
-      backgroundColor: '#D7E3FC',
-    },
-  },
-};
+const defaultBorderColor = '#007D88';
+const defaultBackgroundColor = '#D7E3FC';
 
 // eslint-disable-next-line import/prefer-default-export
 export function useEnterpriseCustomerConfig() {
   const { enterpriseSlug } = useParams();
-  const [enterpriseConfig, setEnterpriseConfig] = useState(initialConfig);
+  const [enterpriseConfig, setEnterpriseConfig] = useState(undefined);
 
   useEffect(() => {
     fetchEntepriseCustomerConfig(enterpriseSlug)
       .then((response) => {
         const { results } = camelCaseObject(response.data);
         const config = results.pop();
-        if (config) {
+        if (config && config.enableLearnerPortal) {
           const {
             name,
             uuid,
@@ -49,15 +38,18 @@ export function useEnterpriseCustomerConfig() {
             branding: {
               logo,
               banner: {
-                backgroundColor: bannerBackgroundColor || initialConfig.branding.banner.backgroundColor,
-                borderColor: bannerBorderColor || initialConfig.branding.banner.borderColor,
+                backgroundColor: bannerBackgroundColor || defaultBackgroundColor,
+                borderColor: bannerBorderColor || defaultBorderColor,
               },
             },
           });
+        } else {
+          setEnterpriseConfig(null);
         }
       })
       .catch((error) => {
         logError(new Error(error));
+        setEnterpriseConfig(null);
       });
   }, [enterpriseSlug]);
 


### PR DESCRIPTION
We show the "Not found/404" page for the following cases:
* A user hits the route for an enterprise that doesn't exist
* A user hits the route for an enterprise that does not have the
  learner portal enabled
* A user hits the application root "/"
* A user hits the route for an enterprise that does have the learner
  portal enabled, but the learner is not linked to that enterprise

[ENT-2655](https://openedx.atlassian.net/browse/ENT-2655)