### PR TITLE
Don't render Layout until metadata is fetched

### DIFF
--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -12,7 +12,7 @@ export default function EnterprisePage({ children }) {
   const [enterpriseConfig] = useEnterpriseCustomerConfig();
 
   const user = getAuthenticatedUser();
-  const { username } = user;
+  const { username, profileImage } = user;
 
   // We explicitly set enterpriseConfig to null if there is no configuration, the learner portal is
   // not enabled, or there was an error fetching the configuration. In all these cases, we want to 404.
@@ -20,7 +20,8 @@ export default function EnterprisePage({ children }) {
     return <NotFoundPage />;
   }
 
-  if (!enterpriseConfig || !enterpriseConfig.name) {
+  // Render the app as loading while waiting on the configuration or additional user metadata
+  if (!enterpriseConfig || !enterpriseConfig.name || !profileImage) {
     return (
       <div className="py-5">
         <LoadingSpinner screenReaderText="loading company details" />

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -17,7 +17,7 @@ export default function Layout({ children }) {
   const user = getAuthenticatedUser();
   const {
     username,
-    profileImage = {},
+    profileImage,
   } = user;
 
   function getHeaderMenuItems(key) {


### PR DESCRIPTION
Adds in a check to make sure the additional user emtadata has been
fetched before rendering the Layout component.

ENT-2652