### PR TITLE
Add 2 ADRs to document decisions related to Gatsby and portal-designer

### DIFF
--- a/docs/decisions/0001-record-architecture-decisions.rst
+++ b/docs/decisions/0001-record-architecture-decisions.rst
@@ -1,0 +1,37 @@
+================================
+1. Record Architecture Decisions
+================================
+
+******
+Status
+******
+
+Accepted
+
+*******
+Context
+*******
+
+We would like to keep a historical record on the architectural decisions we make with this app as it evolves over time.
+
+********
+Decision
+********
+
+We will use Architecture Decision Records, as described by 
+Michael Nygard in `Documenting Architecture Decisions`_
+
+.. _Documenting Architecture Decisions: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+************
+Consequences
+************
+
+See Michael Nygard's article, linked above.
+
+**********
+References
+**********
+
+* https://resources.sei.cmu.edu/asset_files/Presentation/2017_017_001_497746.pdf
+* https://github.com/npryce/adr-tools/tree/master/doc/adr

--- a/docs/decisions/0002-no-longer-rely-on-portal-designer.rst
+++ b/docs/decisions/0002-no-longer-rely-on-portal-designer.rst
@@ -1,0 +1,71 @@
+========================================
+2. No longer rely on ``portal-designer``
+========================================
+
+******
+Status
+******
+
+Accepted
+
+*******
+Context
+*******
+
+The ``portal-designer`` (or ``designer`` for short) service is a Wagtail/Django-based content management system (CMS) that was created in order to provide basic configuration data on a site-by-site basis for the Programs and Enterprise learner portal frontend applications. 
+
+For example, an individual Enterprise Customer (e.g., "Pied Piper") would have an associated site and "Enterprise Page" created in ``designer`` in order to configure the learner portal for that Enterprise. The configuration data for an individual Enterprise Customer consists of:
+
+* Enterprise Customer uuid (from the ``EnterpriseCustomer`` model in ``edx-enterprise`` / LMS)
+* Enterprise Customer name
+* Learning coordinator email address (exposes to enterprise learners in the learner portal)
+* Branding configuration
+    * Logo image
+    * Banner colors (background/border)
+
+As mentioned above, ``designer`` is also used to configure the Programs learner portals for each Master's degree for a given university partner (i.e., site). However, the configuration data for Programs differs from the configuration data for an Enterprise. For example, the learner portal for a Program might be configured to show links to program-related documents, render static text in the sidebar of that program's learner portal, or use custom background images in the banner.
+
+Additionally, the ``designer`` service provides an API that is called during the build process for the Programs and Enterprise learner portals in order to gather the necessary configuration data for each Program or Enterprise learner portal.
+
+However, by configuring the Programs and Enterprise learner portals in the same ``designer`` service, we are introducing a bit of a tight coupling between Programs and Enterprise, despite the configuration data being different for each learner portal. Further, as time goes on, the configuration for Enterprise and Programs learner portals will likely continue to diverge.
+
+Data Duplication for Enterprise Customer Configuration
+======================================================
+
+By configuring the Enterprise learner portal data through ``designer``, we inevitably introduced data duplication between ``designer`` and the Enterprise Customer configuration that is done through Django admin in the LMS (via ``edx-enterprise``).
+
+The Enterprise Customer configuration done in Django admin already includes the majority of data the Enterprise learner portal relies on: the Enterprise Customer's uuid, name, and logo image. The same data needs to be configured in the ``designer`` service for each Enterprise Customer, leading to the data duplication across ``designer`` and the LMS.
+
+********
+Decision
+********
+
+Due to the challenges outlined above, the Enterprise learner portal will no longer rely on the ``designer`` service. Instead, the configuration data for an Enterprise learner portal will be added to the Django admin page within the LMS (via ``edx-enterprise``):
+
+* Branding configuration for the banner
+    * Fields for the background and border HEX color values will be added to the ``EnterpriseCustomerBrandingConfiguration`` model.
+* Learning coordinator email address
+    * A field for this data will be added to the ``EnterpriseCustomer`` model.
+* A field will be added to the ``EnterpriseCustomer`` model to specify which Enterprise Customers have the learner portal enabled.
+
+These changes within ``edx-enterprise`` will remove our data dependency on ``designer`` and allow us to instead fetch the necessary data for the Enterprise learner portal through existing API endpoint(s) in ``edx-enterprise``.
+
+************
+Consequences
+************
+
+The decision to no longer rely on the ``designer`` service to fetch the configuration data about an Enterprise learner portal has the following consequences:
+
+1. Engineers and other internal teams (e.g., ECS) that configure the metadata for Enterprise Customers will no need to configure data in two separate places.
+2. There will no longer be data duplication between the Enterprise Customer metadata defined in the LMS (via ``edx-enterprise``) and ``designer``. Instead, the configured data in the LMS will become the "source of truth" for the Enterprise learner portal.
+3. Configuration for the Enterprise learner portal will no longer be tightly coupled to the configuration for the Programs learner portal.
+4. The Enterprise engineering team will transition ownership of ``designer`` to the Programs team.
+5. A tech debt ticket will be added to the Enterprise engineering backlog to remove any models/views/etc. related to Enterprise from the ``designer`` service (ENT-2553).
+
+**********
+References
+**********
+
+* https://github.com/edx/portal-designer/
+* https://github.com/edx/portal-designer/blob/master/docs/decisions/0001-new-designer-service.rst
+

--- a/docs/decisions/0002-no-longer-rely-on-portal-designer.rst
+++ b/docs/decisions/0002-no-longer-rely-on-portal-designer.rst
@@ -27,7 +27,16 @@ As mentioned above, ``designer`` is also used to configure the Programs learner 
 
 Additionally, the ``designer`` service provides an API that is called during the build process for the Programs and Enterprise learner portals in order to gather the necessary configuration data for each Program or Enterprise learner portal.
 
-However, by configuring the Programs and Enterprise learner portals in the same ``designer`` service, we are introducing a bit of a tight coupling between Programs and Enterprise, despite the configuration data being different for each learner portal. Further, as time goes on, the configuration for Enterprise and Programs learner portals will likely continue to diverge.
+However, by configuring the Programs and Enterprise learner portals in the same ``designer`` service, we introduced a somewhat tight coupling between Programs and Enterprise, despite the configuration data being different for each learner portal. Further, as time goes on, the configuration for Enterprise and Programs learner portals will likely continue to diverge.
+
+Requirements for a Full-Featured CMS
+====================================
+
+The ``designer`` service is a customizable CMS based on Wagtail that could support granting access for Enterprise Admins to update the learner portal configuration for their associated Enterprise Customer with a self-service approach. However, this is not an explicit requirement at this time. Instead, we aim to provide some lightweight customizations to the learner portal for specific Enterprise Customers; these customizations will initially be done by internal admins (e.g., the ECS team).
+
+That said, it is possible we may need to provide a more self-service solution to our Enterprise Customers in the future, or when the learner portal customizations become more complex. In this case, we may begin using to ``designer`` at that time. For now, though, using ``designer`` to support the lightweight customizations we provide today is not necessary.
+
+Even then, we could build a new page within the Enterprise Admin Dashboard to support self-service customizations to an Enterprise Customer's learner portal configuration instead of utilizing a full-featured CMS. This would also mean that an Enterprise Admin would not need to use any services/products beyond the Admin Dashboard. 
 
 Data Duplication for Enterprise Customer Configuration
 ======================================================
@@ -56,7 +65,7 @@ Consequences
 
 The decision to no longer rely on the ``designer`` service to fetch the configuration data about an Enterprise learner portal has the following consequences:
 
-1. Engineers and other internal teams (e.g., ECS) that configure the metadata for Enterprise Customers will no need to configure data in two separate places.
+1. Engineers and other internal teams (e.g., ECS) that configure the metadata for Enterprise Customers will not need to configure data in two separate places.
 2. There will no longer be data duplication between the Enterprise Customer metadata defined in the LMS (via ``edx-enterprise``) and ``designer``. Instead, the configured data in the LMS will become the "source of truth" for the Enterprise learner portal.
 3. Configuration for the Enterprise learner portal will no longer be tightly coupled to the configuration for the Programs learner portal.
 4. The Enterprise engineering team will transition ownership of ``designer`` to the Programs team.
@@ -68,4 +77,3 @@ References
 
 * https://github.com/edx/portal-designer/
 * https://github.com/edx/portal-designer/blob/master/docs/decisions/0001-new-designer-service.rst
-

--- a/docs/decisions/0003-static-builds-to-client-side-react.rst
+++ b/docs/decisions/0003-static-builds-to-client-side-react.rst
@@ -14,6 +14,8 @@ Context
 
 Currently, the Enterprise and Programs learner portals are created using Gatsby, a static site generator based on React. Gatsby works by sourcing data (e.g., from external APIs) and creates static web pages (i.e., HTML, CSS, JavaScript) during the build process. This contrasts from a standard React application (or "microfrontend") where data is fetched client-side, or after the app has already been loaded in the browser. The Enterprise and Programs learner portals both utilize a custom Gatsby plugin to fetch the necessary data about learner portal configurations from the ``portal-designer`` service (i.e., ``gatsby-source-portal-designer``).
 
+**Note:** The Enterprise learner portal no longer sources its data from ``portal-designer``; instead, the data that the Enterprise learner portal depends on is now defined within the LMS (via ``edx-enterprise``). See `this ADR <0002-no-longer-rely-on-portal-designer.rst>`_ for more details.
+
 Statically-built sites with Gatsby offer the following benefits over a client-side React app:
 
 * **SEO.** Web crawlers can more easily parse the HTML source of a static site to understand what a given page is about, as opposed to a client-side app where the HTML is created via JavaScript on the fly.
@@ -25,13 +27,15 @@ Taking the course detail pages as an example, let's assume a worst-case scenario
 
 An argument might be made that we could implement a hybrid approach, where we only build each course page once and dynamically fetch the Enterprise Customer's data (e.g., logo, name, branding) client-side. However, at that point, we would not really be taking full advantage of Gatsby as a static site generator. Resources online point to scenarios such as this, where most of an application uses dynamic data, as rationale for not using Gatsby (see References).
 
+Additionally, as a statically-built site, whenever data is updated (e.g., a different logo is uploaded for an Enterprise Customer), a rebuild of the Enterprise learner portal would need to occur in order to pull in the data changes. This presents a potential scalability issue in terms of how we would be able support 500+ Enterprise Customers; we would likely need to build a mechanism that triggers a rebuild and redeploy of the Enterprise learner portal for any change to the data that the Enterprise learner portal depends on. By moving away from Gatsby and its static build process, any changes to the data by internal admins (e.g., the ECS team) will appear instantaneously within the Enterprise learner portal, without any engineering intervention. This is not as much of an issue for the Programs learner portal, as there are a more finite number of Programs when compared to the number of Enterprise Customers.
+
 ********
 Decision
 ********
 
 While it would be great if the Enterprise learner portal could take advantage of the benefits for using Gatsby (e.g., faster page loads), it does not make as much sense given the tradeoffs mentioned above. This is because the Enterprise learner portal relies mostly on dynamic data in such a way that would not allow us to realize the advantage of a statically rendered app. Additionally, the Enterprise learner portal does not have a requirement for supporting SEO best practices since it is used by existing customers (presumably with direct access to the URL) as opposed to a marketing site that will be crawled by search engine bots.
 
-That said, we will be migrating the Enterprise learner portal off of Gatsby and its multi-site build process / infrastructure. Instead, the Enterprise learner portal will become a standard client-side React application (microfrontend) that utilizes many of the recent advancements in the frontend ecosystem at edX (e.g., ``@edx/frontend-build``, ``@edx/frontend-platform``).
+That said, we will be migrating the Enterprise learner portal off of Gatsby and its multi-site build process / infrastructure. Instead, the Enterprise learner portal will become a standard client-side React application (microfrontend) that utilizes many of the recent advancements in the frontend ecosystem at edX (e.g., ``@edx/frontend-build``, ``@edx/frontend-platform``). In addition, the Enterprise learner portal will no longer rely on the shared UI components in ``@edx/frontend-learner-portal-base``.
 
 ************
 Consequences
@@ -39,9 +43,10 @@ Consequences
 
 * Rather than sourcing the necessary configuration data during the build process, data for the Enterprise learner portal will be fetched client-side as needed from the browser.
     * That said, we will want to be intentional about how we do client-side data fetching to reduce the amount of perceived loading time for the user.
+    * Additionally, any updates to the data by internal admins (e.g., the ECS team) will propogate immediately instead of needing to trigger a rebuild/redeploy.
 * The Enterprise learner portal will no longer use multi-site build process / infrastructure. Rather, the Enterprise learner portal will use the same build process and infrastructure as other standard microfrontends at edX.
 * The Enterprise learner portal will begin using ``@edx/frontend-build`` and ``@edx/frontend-platform`` to be in line with other microfrontends at edX and reduce common boilerplate.
-* Ownership of the ``gatsby-source-portal-designer`` Gatsby plugin will be transitioned to the Programs engineering team(s).
+* Ownership of the ``gatsby-source-portal-designer`` Gatsby plugin and the ``@edx/frontend-learner-portal-base`` NPM package will be transitioned to the Programs engineering team(s).
 
 **********
 References
@@ -49,6 +54,7 @@ References
 
 * https://www.gatsbyjs.org/
 * https://github.com/edx/gatsby-source-portal-designer
+* https://github.com/edx/frontend-learner-portal-base
 * https://dev.to/maniekm/when-not-to-use-gatsbyjs-oic
 * https://blog.jakoblind.no/gatsby-vs-next/
 * https://github.com/edx/frontend-platform

--- a/docs/decisions/0003-static-builds-to-client-side-react.rst
+++ b/docs/decisions/0003-static-builds-to-client-side-react.rst
@@ -1,0 +1,55 @@
+============================================================
+3. Move from static builds (Gatsby) to client-side React app
+============================================================
+
+******
+Status
+******
+
+Accepted
+
+*******
+Context
+*******
+
+Currently, the Enterprise and Programs learner portals are created using Gatsby, a static site generator based on React. Gatsby works by sourcing data (e.g., from external APIs) and creates static web pages (i.e., HTML, CSS, JavaScript) during the build process. This contrasts from a standard React application (or "microfrontend") where data is fetched client-side, or after the app has already been loaded in the browser. The Enterprise and Programs learner portals both utilize a custom Gatsby plugin to fetch the necessary data about learner portal configurations from the ``portal-designer`` service (i.e., ``gatsby-source-portal-designer``).
+
+Statically-built sites with Gatsby offer the following benefits over a client-side React app:
+
+* **SEO.** Web crawlers can more easily parse the HTML source of a static site to understand what a given page is about, as opposed to a client-side app where the HTML is created via JavaScript on the fly.
+* **Faster page load times.** Data is gathered during the build process and subsequently injected into the static pages; there's no need to fetch data client-side. Additionally, Gatsby prefetches pages when using its internal router, making page transitions quick.
+
+Despite these primary benefits, using Gatsby comes with a few tradeoffs that influence whether it is the right choice for the Enterprise learner portal moving forward. At the time Gatsby was introduced, the Enterprise learner portal was essentially a single dashboard page for enterprise learners to see their current, upcoming, and completed course enrollments associated with their Enterprise. This page also contains basic branding specific to the Enterprise (i.e., logo, colors, etc.). However, as we build out a more robust learner experience within the Enterprise learner portal, we plan to add additional pages such as a search/filter course discovery experience and course detail pages. Each of these pages will persist the Enterprise Customer's logo, name, and branding.
+
+Taking the course detail pages as an example, let's assume a worst-case scenario where we have 500 Enterprise Customers, each with a course catalog that grants access to all edX content (i.e., ~2500 courses). In this scenario, because each course detail page has branding that is unique to each individual Enterprise Customer, we would potentially need to build 1,250,000 static pages to support the course catalogs of those 500 Enterprise Customers. This would lead to long build times that would slow down development, testing, and rolling out production bug fixes.
+
+An argument might be made that we could implement a hybrid approach, where we only build each course page once and dynamically fetch the Enterprise Customer's data (e.g., logo, name, branding) client-side. However, at that point, we would not really be taking full advantage of Gatsby as a static site generator. Resources online point to scenarios such as this, where most of an application uses dynamic data, as rationale for not using Gatsby (see References).
+
+********
+Decision
+********
+
+While it would be great if the Enterprise learner portal could take advantage of the benefits for using Gatsby (e.g., faster page loads), it does not make as much sense given the tradeoffs mentioned above. This is because the Enterprise learner portal relies mostly on dynamic data in such a way that would not allow us to realize the advantage of a statically rendered app. Additionally, the Enterprise learner portal does not have a requirement for supporting SEO best practices since it is used by existing customers (presumably with direct access to the URL) as opposed to a marketing site that will be crawled by search engine bots.
+
+That said, we will be migrating the Enterprise learner portal off of Gatsby and its multi-site build process / infrastructure. Instead, the Enterprise learner portal will become a standard client-side React application (microfrontend) that utilizes many of the recent advancements in the frontend ecosystem at edX (e.g., ``@edx/frontend-build``, ``@edx/frontend-platform``).
+
+************
+Consequences
+************
+
+* Rather than sourcing the necessary configuration data during the build process, data for the Enterprise learner portal will be fetched client-side as needed from the browser.
+    * That said, we will want to be intentional about how we do client-side data fetching to reduce the amount of perceived loading time for the user.
+* The Enterprise learner portal will no longer use multi-site build process / infrastructure. Rather, the Enterprise learner portal will use the same build process and infrastructure as other standard microfrontends at edX.
+* The Enterprise learner portal will begin using ``@edx/frontend-build`` and ``@edx/frontend-platform`` to be in line with other microfrontends at edX and reduce common boilerplate.
+* Ownership of the ``gatsby-source-portal-designer`` Gatsby plugin will be transitioned to the Programs engineering team(s).
+
+**********
+References
+**********
+
+* https://www.gatsbyjs.org/
+* https://github.com/edx/gatsby-source-portal-designer
+* https://dev.to/maniekm/when-not-to-use-gatsbyjs-oic
+* https://blog.jakoblind.no/gatsby-vs-next/
+* https://github.com/edx/frontend-platform
+* https://github.com/edx/frontend-build


### PR DESCRIPTION
This PR includes 2 ADRs, documenting why we are:
1. Moving away from the `portal-designer` service
2. No longer using Gatsby (static site generator), and instead transitioning to a standard microfrontend.

It also adds an initial ADR documenting what an ADR is (noticed other repos have this, too).