### PR TITLE
Change 'Catalog' Link

### DIFF
--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -33,7 +33,7 @@ export default function CourseHeader() {
             {primarySubject && (
               <Breadcrumb
                 links={[
-                  { label: 'Catalog', url: process.env.CATALOG_BASE_URL },
+                  { label: 'Find a course', url: process.env.CATALOG_BASE_URL },
                   {
                     label: `${primarySubject.name} Courses`,
                     url: primarySubject.url,

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -39,7 +39,7 @@ export default function EnterprisePage({ children }) {
             {
               type: 'item',
               href: process.env.CATALOG_BASE_URL,
-              content: 'Catalog',
+              content: 'Find a course',
             },
             {
               type: 'item',


### PR DESCRIPTION
The Learner Portal header contains a link to the list of courses. Previously, the link was titled 'Catalog' and it has now been renamed to 'Find a course' (links to B2C page for now).

Updated Title:

<img width="1478" alt="Renamed Header" src="https://user-images.githubusercontent.com/29842282/84419775-1537e080-abe7-11ea-888f-289ca721df6f.png">

Link to associated ticket: https://openedx.atlassian.net/browse/ENT-2989
