### PR TITLE
Add support for customizable colors, including choosing appropriate text color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4708,7 +4708,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
       "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -4731,7 +4730,6 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -15676,7 +15674,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -15684,8 +15681,7 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios-mock-adapter": "^1.15.0",
     "babel-jest": "^24.5.0",
     "classnames": "^2.2.5",
+    "color": "^3.1.2",
     "connected-react-router": "^5.0.1",
     "core-js": "^3.6.4",
     "email-prop-type": "^1.1.5",

--- a/src/components/course/CourseRunSelector.jsx
+++ b/src/components/course/CourseRunSelector.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useRef } from 'react';
 import moment from 'moment';
-import { Input } from '@edx/paragon';
+import { Button, Input } from '@edx/paragon';
 
 import { CourseContext } from './CourseContextProvider';
 import { SET_COURSE_RUN } from './data/constants';
@@ -49,9 +49,13 @@ export default function CourseRunSelector() {
           }
           ref={selectRef}
         />
-        <button type="button" className="btn btn-primary ml-2" onClick={() => handleClick()}>
+        <Button
+          buttonType="primary"
+          className="btn-brand-primary ml-2"
+          onClick={() => handleClick()}
+        >
           go
-        </button>
+        </Button>
       </div>
     );
   }

--- a/src/components/course/CourseSidebar.jsx
+++ b/src/components/course/CourseSidebar.jsx
@@ -14,13 +14,13 @@ import { CourseContext } from './CourseContextProvider';
 import CourseSidebarListItem from './CourseSidebarListItem';
 import CourseAssociatedPrograms from './CourseAssociatedPrograms';
 
+import { isDefined, isDefinedAndNotNull } from '../../utils/common';
 import {
   useCourseSubjects,
   useCoursePartners,
   useCourseRunWeeksToComplete,
   useCourseTranscriptLanguages,
 } from './data/hooks';
-import { isDefined } from './data/utils';
 
 import './styles/CourseSidebar.scss';
 
@@ -35,19 +35,23 @@ export default function CourseSidebar() {
   return (
     <>
       <ul className="pl-0 mb-5 course-details-sidebar">
-        {isDefined(activeCourseRun.weeksToComplete) && (
-          <CourseSidebarListItem
-            icon={faClock}
-            label="Length"
-            content={`${weeksToComplete} ${weeksLabel}`}
-          />
-        )}
-        {isDefined(activeCourseRun.minEffort) && isDefined(activeCourseRun.maxEffort) && (
-          <CourseSidebarListItem
-            icon={faTachometerAlt}
-            label="Effort"
-            content={`${activeCourseRun.minEffort}-${activeCourseRun.maxEffort} hours per week`}
-          />
+        {isDefined(activeCourseRun) && (
+          <>
+            {isDefinedAndNotNull(activeCourseRun.weeksToComplete) && (
+              <CourseSidebarListItem
+                icon={faClock}
+                label="Length"
+                content={`${weeksToComplete} ${weeksLabel}`}
+              />
+            )}
+            {isDefinedAndNotNull([activeCourseRun.minEffort, activeCourseRun.maxEffort]) && (
+              <CourseSidebarListItem
+                icon={faTachometerAlt}
+                label="Effort"
+                content={`${activeCourseRun.minEffort}-${activeCourseRun.maxEffort} hours per week`}
+              />
+            )}
+          </>
         )}
         <CourseSidebarListItem
           icon={faTag}

--- a/src/components/course/CourseSidebar.jsx
+++ b/src/components/course/CourseSidebar.jsx
@@ -14,7 +14,7 @@ import { CourseContext } from './CourseContextProvider';
 import CourseSidebarListItem from './CourseSidebarListItem';
 import CourseAssociatedPrograms from './CourseAssociatedPrograms';
 
-import { isDefined, isDefinedAndNotNull } from '../../utils/common';
+import { isDefinedAndNotNull } from '../../utils/common';
 import {
   useCourseSubjects,
   useCoursePartners,
@@ -35,7 +35,7 @@ export default function CourseSidebar() {
   return (
     <>
       <ul className="pl-0 mb-5 course-details-sidebar">
-        {isDefined(activeCourseRun) && (
+        {isDefinedAndNotNull(activeCourseRun) && (
           <>
             {isDefinedAndNotNull(activeCourseRun.weeksToComplete) && (
               <CourseSidebarListItem

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -106,7 +106,3 @@ export function getProgramIcon(type) {
       return VerifiedSvgIcon;
   }
 }
-
-export function isDefined(value) {
-  return value !== undefined && value !== null;
-}

--- a/src/components/dashboard/main-content/DashboardMainContent.jsx
+++ b/src/components/dashboard/main-content/DashboardMainContent.jsx
@@ -15,7 +15,7 @@ const DashboardMainContent = () => {
         To start taking a course, browse the catalog below.
       </p>
       <p>
-        <a href={`/${slug}/search`} className="btn btn-primary">
+        <a href={`/${slug}/search`} className="btn btn-primary brand-btn-primary">
           Browse full catalog
         </a>
       </p>

--- a/src/components/dashboard/main-content/DashboardMainContent.jsx
+++ b/src/components/dashboard/main-content/DashboardMainContent.jsx
@@ -15,7 +15,7 @@ const DashboardMainContent = () => {
         To start taking a course, browse the catalog below.
       </p>
       <p>
-        <a href={`/${slug}/search`} className="btn btn-primary brand-btn-primary">
+        <a href={`/${slug}/search`} className="btn btn-primary btn-brand-primary">
           Browse full catalog
         </a>
       </p>

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx
@@ -164,7 +164,7 @@ class EmailSettingsModal extends Component {
               complete: 'Saved',
             }}
             disabledStates={this.getDisabledStates()}
-            className="save-email-settings-btn btn-primary"
+            className="save-email-settings-btn btn-primary btn-brand-primary"
             state={this.getButtonState()}
             onClick={this.handleSaveButtonClick}
             key="save-email-settings-btn"

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
@@ -83,7 +83,7 @@ const MarkCompleteModal = ({
               pending: MARK_ARCHIVED_PENDING_LABEL,
             }}
             disabledStates={['pending']}
-            className="confirm-mark-complete-btn btn-primary"
+            className="confirm-mark-complete-btn btn-primary btn-brand-primary"
             state={confirmButtonState}
             onClick={handleConfirmButtonClick}
             key="confirm-mark-complete-btn"

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unarchive-modal/UnarchiveModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unarchive-modal/UnarchiveModal.jsx
@@ -74,7 +74,7 @@ const UnarchiveModal = ({
               pending: MARK_UNARCHIVED_PENDING_LABEL,
             }}
             disabledStates={['pending']}
-            className="confirm-unarchive-btn btn-primary"
+            className="confirm-unarchive-btn btn-primary btn-brand-primary"
             state={confirmButtonState}
             onClick={handleConfirmButtonClick}
             key="confirm-unarchive-btn"

--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -7,9 +7,9 @@ export default function EnterpriseBanner() {
   const { enterpriseConfig } = useContext(AppContext);
 
   return (
-    <div className="enterprise-banner brand-bg-secondary">
+    <div className="enterprise-banner bg-brand-secondary">
       <div className="container-fluid">
-        <h1 className="mb-0 py-3 pl-3 brand-border-tertiary">{enterpriseConfig.name}</h1>
+        <h1 className="mb-0 py-3 pl-3 border-brand-tertiary">{enterpriseConfig.name}</h1>
       </div>
     </div>
   );

--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -1,25 +1,15 @@
 import React, { useContext } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 
+import './styles/EnterpriseBanner.scss';
+
 export default function EnterpriseBanner() {
-  const {
-    enterpriseConfig: {
-      name,
-      branding: {
-        banner: {
-          backgroundColor,
-          borderColor,
-        },
-      },
-    },
-  } = useContext(AppContext);
+  const { enterpriseConfig } = useContext(AppContext);
 
   return (
-    <div style={{ backgroundColor }}>
+    <div className="enterprise-banner brand-bg-secondary">
       <div className="container-fluid">
-        <h1 className="mb-0 py-3 pl-3" style={{ borderLeft: `15px solid ${borderColor}` }}>
-          {name}
-        </h1>
+        <h1 className="mb-0 py-3 pl-3 brand-border-tertiary">{enterpriseConfig.name}</h1>
       </div>
     </div>
   );

--- a/src/components/enterprise-banner/styles/EnterpriseBanner.scss
+++ b/src/components/enterprise-banner/styles/EnterpriseBanner.scss
@@ -1,0 +1,6 @@
+.enterprise-banner {
+  h1 {
+    border-left-width: 15px;
+    border-left-style: solid;
+  }
+}

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -7,6 +7,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { LoadingSpinner } from '../loading-spinner';
 import NotFoundPage from '../NotFoundPage';
 
+import { isDefined, isDefinedAndNull } from '../../utils/common';
 import { useEnterpriseCustomerConfig } from './data/hooks';
 
 export default function EnterprisePage({ children }) {
@@ -16,19 +17,19 @@ export default function EnterprisePage({ children }) {
   const user = getAuthenticatedUser();
   const { username, profileImage } = user;
 
-  // We explicitly set enterpriseConfig to null if there is no configuration, the learner portal is
-  // not enabled, or there was an error fetching the configuration. In all these cases, we want to 404.
-  if (enterpriseConfig === null) {
-    return <NotFoundPage />;
-  }
-
   // Render the app as loading while waiting on the configuration or additional user metadata
-  if (!enterpriseConfig || !enterpriseConfig.name || !profileImage) {
+  if (!isDefined(enterpriseConfig) || !isDefined(profileImage)) {
     return (
       <div className="py-5">
         <LoadingSpinner screenReaderText="loading company details" />
       </div>
     );
+  }
+
+  // We explicitly set enterpriseConfig to null if there is no configuration, the learner portal is
+  // not enabled, or there was an error fetching the configuration. In all these cases, we want to 404.
+  if (isDefinedAndNull(enterpriseConfig)) {
+    return <NotFoundPage />;
   }
 
   return (

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -4,13 +4,15 @@ import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import { fetchEnterpriseCustomerConfig } from './service';
 
-export const defaultBorderColor = '#007D88';
-export const defaultBackgroundColor = '#D7E3FC';
+export const defaultPrimaryColor = '#1a337b';
+export const defaultSecondaryColor = '#d7e3fc';
+export const defaultTertiaryColor = '#007d88';
 
 const defaultBrandingConfig = {
   logo: null,
-  bannerBackgroundColor: defaultBackgroundColor,
-  bannerBorderColor: defaultBorderColor,
+  primaryColor: defaultPrimaryColor,
+  secondaryColor: defaultSecondaryColor,
+  tertiaryColor: defaultTertiaryColor,
 };
 
 /**
@@ -28,6 +30,8 @@ export function useEnterpriseCustomerConfig(enterpriseSlug) {
         const config = results.pop();
         if (config && config.enableLearnerPortal) {
           const brandingConfiguration = config.brandingConfiguration || defaultBrandingConfig;
+          // TODO: bannerBackgroundColor and bannerBorderColor will be replaced by
+          // secondaryColor and tertiaryColor, respectively.
           const {
             logo,
             bannerBackgroundColor,
@@ -46,9 +50,13 @@ export function useEnterpriseCustomerConfig(enterpriseSlug) {
             contactEmail,
             branding: {
               logo,
-              banner: {
-                backgroundColor: bannerBackgroundColor || defaultBackgroundColor,
-                borderColor: bannerBorderColor || defaultBorderColor,
+              colors: {
+                // TODO: this will eventually change to `primaryColor || defaultPrimaryColor`
+                primary: defaultPrimaryColor,
+                // TODO: this will eventually change to `secondaryColor || defaultSecondaryColor`
+                secondary: bannerBackgroundColor || defaultSecondaryColor,
+                // TODO: this will eventually change to `tertiaryColor || defaultTertiaryColor`
+                tertiary: bannerBorderColor || defaultTertiaryColor,
               },
             },
           });

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -19,7 +19,7 @@ const defaultBrandingConfig = {
  */
 // eslint-disable-next-line import/prefer-default-export
 export function useEnterpriseCustomerConfig(enterpriseSlug) {
-  const [enterpriseConfig, setEnterpriseConfig] = useState(undefined);
+  const [enterpriseConfig, setEnterpriseConfig] = useState();
 
   useEffect(() => {
     fetchEnterpriseCustomerConfig(enterpriseSlug)

--- a/src/components/enterprise-page/data/tests/customerConfig.test.js
+++ b/src/components/enterprise-page/data/tests/customerConfig.test.js
@@ -2,8 +2,9 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import {
   useEnterpriseCustomerConfig,
-  defaultBorderColor,
-  defaultBackgroundColor,
+  defaultPrimaryColor,
+  defaultSecondaryColor,
+  defaultTertiaryColor,
 } from '../hooks';
 import { fetchEnterpriseCustomerConfig } from '../service';
 
@@ -41,8 +42,8 @@ const responseWithBrandingConfig = {
         ...responseWithNullBrandingConfig.data.results[0],
         branding_configuration: {
           logo: 'testlogo.png',
-          bannerBackgroundColor: 'testcolor',
-          bannerBorderColor: 'testcolor',
+          bannerBackgroundColor: 'secondaryColor',
+          bannerBorderColor: 'tertiaryColor',
         },
       },
     ],
@@ -78,8 +79,9 @@ describe('customer config with various states of branding_configuration', () => 
     expect(result.error).not.toBeDefined();
     expect(result.current).not.toBeNull();
     expect(result.current.branding.logo).toBeNull();
-    expect(result.current.branding.banner.backgroundColor).toBe(defaultBackgroundColor);
-    expect(result.current.branding.banner.borderColor).toBe(defaultBorderColor);
+    expect(result.current.branding.colors.primary).toBe(defaultPrimaryColor);
+    expect(result.current.branding.colors.secondary).toBe(defaultSecondaryColor);
+    expect(result.current.branding.colors.tertiary).toBe(defaultTertiaryColor);
   });
 
   test('null values for fields in branding_config uses defaults and does not fail', async () => {
@@ -93,8 +95,9 @@ describe('customer config with various states of branding_configuration', () => 
     expect(result.error).not.toBeDefined();
     expect(result.current).not.toBeNull();
     expect(result.current.branding.logo).toBeNull();
-    expect(result.current.branding.banner.backgroundColor).toBe(defaultBackgroundColor);
-    expect(result.current.branding.banner.borderColor).toBe(defaultBorderColor);
+    expect(result.current.branding.colors.primary).toBe(defaultPrimaryColor);
+    expect(result.current.branding.colors.secondary).toBe(defaultSecondaryColor);
+    expect(result.current.branding.colors.tertiary).toBe(defaultTertiaryColor);
   });
 
   test('valid branding_config results in correct values for logo and other branding settings', async () => {
@@ -107,7 +110,8 @@ describe('customer config with various states of branding_configuration', () => 
     expect(result.error).not.toBeDefined();
     expect(result.current).not.toBeNull();
     expect(result.current.branding.logo).toBe('testlogo.png');
-    expect(result.current.branding.banner.backgroundColor).toBe('testcolor');
-    expect(result.current.branding.banner.borderColor).toBe('testcolor');
+    expect(result.current.branding.colors.primary).toBe(defaultPrimaryColor);
+    expect(result.current.branding.colors.secondary).toBe('secondaryColor');
+    expect(result.current.branding.colors.tertiary).toBe('tertiaryColor');
   });
 });

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -11,25 +11,25 @@ import EdXLogo from '../../assets/edx-logo.svg';
 import './styles/Layout.scss';
 
 export default function Layout({ children }) {
-  const context = useContext(AppContext);
-  const { enterpriseConfig } = context;
+  const { enterpriseConfig, header } = useContext(AppContext);
 
   const user = getAuthenticatedUser();
-  const {
-    username,
-    profileImage,
-  } = user;
+  const { username, profileImage } = user;
 
-  function getHeaderMenuItems(key) {
-    const { header } = context;
-    return header[key] || [];
-  }
+  const getHeaderMenuItems = key => header[key] || [];
 
   return (
     <IntlProvider locale="en">
       <>
         <Helmet titleTemplate="%s - edX" defaultTitle="edX">
           <html lang="en" />
+          <style type="text/css">
+            {`
+              body {
+                  background-color: blue;
+              }
+            `}
+          </style>
         </Helmet>
         <SiteHeader
           logo={enterpriseConfig.branding.logo || EdXLogo}

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,17 +1,20 @@
 import React, { useContext } from 'react';
-import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
+import { Helmet } from 'react-helmet';
 import { IntlProvider } from 'react-intl';
 import SiteHeader from '@edx/frontend-component-site-header';
 import SiteFooter from '@edx/frontend-component-footer';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
+import { useStylesForCustomBrandColors } from './data/hooks';
+
 import EdXLogo from '../../assets/edx-logo.svg';
 import './styles/Layout.scss';
 
 export default function Layout({ children }) {
   const { enterpriseConfig, header } = useContext(AppContext);
+  const brandStyles = useStylesForCustomBrandColors(enterpriseConfig);
 
   const user = getAuthenticatedUser();
   const { username, profileImage } = user;
@@ -23,13 +26,9 @@ export default function Layout({ children }) {
       <>
         <Helmet titleTemplate="%s - edX" defaultTitle="edX">
           <html lang="en" />
-          <style type="text/css">
-            {`
-              body {
-                  background-color: blue;
-              }
-            `}
-          </style>
+          {brandStyles.map(brandStyle => (
+            <style type="text/css">{brandStyle}</style>
+          ))}
         </Helmet>
         <SiteHeader
           logo={enterpriseConfig.branding.logo || EdXLogo}

--- a/src/components/layout/data/hooks.js
+++ b/src/components/layout/data/hooks.js
@@ -3,8 +3,8 @@ import Color from 'color';
 
 import { isDefinedAndNotNull, isDefined } from '../../../utils/common';
 
-const COLOR_LIGHTEN_DARKEN_MODIFER = 0.2;
-const COLOR_MIX_MODIFER = 0.1;
+const COLOR_LIGHTEN_DARKEN_MODIFIER = 0.2;
+const COLOR_MIX_MODIFIER = 0.1;
 
 // eslint-disable-next-line import/prefer-default-export
 export const useStylesForCustomBrandColors = (enterpriseConfig) => {
@@ -27,20 +27,20 @@ export const useStylesForCustomBrandColors = (enterpriseConfig) => {
           dark: darkColor,
           primary: {
             regular: primaryColor,
-            light: primaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFER),
-            dark: primaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFER),
+            light: primaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFIER),
+            dark: primaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFIER),
             textColor: getA11yTextColor(primaryColor),
           },
           secondary: {
             regular: secondaryColor,
-            light: secondaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFER),
-            dark: secondaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFER),
+            light: secondaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFIER),
+            dark: secondaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFIER),
             textColor: getA11yTextColor(secondaryColor),
           },
           tertiary: {
             regular: tertiaryColor,
-            light: tertiaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFER),
-            dark: tertiaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFER),
+            light: tertiaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFIER),
+            dark: tertiaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFIER),
             textColor: getA11yTextColor(tertiaryColor),
           },
         };
@@ -57,37 +57,37 @@ export const useStylesForCustomBrandColors = (enterpriseConfig) => {
   const colors = ['primary', 'secondary', 'tertiary'];
   const styles = colors.map((colorName) => (
     `
-      .brand-btn-${colorName} {
+      .btn-brand-${colorName} {
         background-color: ${brandColors[colorName].regular.hex()} !important;
         border-color: ${brandColors[colorName].regular.hex()} !important;
         color: ${brandColors[colorName].textColor.hex()} !important;
       }
-      .brand-btn-${colorName}:hover {
+      .btn-brand-${colorName}:hover {
         background-color: ${brandColors[colorName].dark.hex()} !important;
         border-color: ${brandColors[colorName].dark.hex()} !important;
       }
-      .brand-btn-${colorName}:focus:before {
+      .btn-brand-${colorName}:focus:before {
         border-color: ${brandColors[colorName].regular.hex()} !important;
       }
 
-      .brand-btn-outline-${colorName} {
+      .btn-brand-outline-${colorName} {
         border-color: ${brandColors[colorName].regular.hex()} !important;
         color: ${brandColors[colorName].regular.hex()} !important;
       }
-      .brand-btn-outline-${colorName}:hover {
+      .btn-outline-${colorName}:hover {
         border-color: ${brandColors[colorName].dark.hex()} !important;
-        background-color: ${brandColors.white.mix(brandColors[colorName].light, COLOR_MIX_MODIFER).hex()} !important;
+        background-color: ${brandColors.white.mix(brandColors[colorName].light, COLOR_MIX_MODIFIER).hex()} !important;
       }
-      .brand-btn-outline-${colorName}:focus:before {
+      .btn-brand-outline-${colorName}:focus:before {
         border-color: ${brandColors[colorName].regular.hex()} !important;
       }
 
-      .brand-bg-${colorName} {
+      .bg-brand-${colorName} {
         background-color: ${brandColors[colorName].regular.hex()} !important;
         color: ${brandColors[colorName].textColor.hex()} !important;
       }
 
-      .brand-border-${colorName} {
+      .border-brand-${colorName} {
         border-color: ${brandColors[colorName].regular.hex()} !important;
       }
     `

--- a/src/components/layout/data/hooks.js
+++ b/src/components/layout/data/hooks.js
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import Color from 'color';
+
+import { isDefinedAndNotNull, isDefined } from '../../../utils/common';
+
+const COLOR_LIGHTEN_DARKEN_MODIFER = 0.2;
+const COLOR_MIX_MODIFER = 0.1;
+
+// eslint-disable-next-line import/prefer-default-export
+export const useStylesForCustomBrandColors = (enterpriseConfig) => {
+  const brandColors = useMemo(
+    () => {
+      if (isDefinedAndNotNull(enterpriseConfig)) {
+        const { branding } = enterpriseConfig;
+
+        const primaryColor = Color(branding.colors.primary);
+        const secondaryColor = Color(branding.colors.secondary);
+        const tertiaryColor = Color(branding.colors.tertiary);
+
+        const whiteColor = Color('#ffffff');
+        const darkColor = Color('#171c29');
+
+        const getA11yTextColor = color => (color.isDark() ? whiteColor : darkColor);
+
+        return {
+          white: whiteColor,
+          dark: darkColor,
+          primary: {
+            regular: primaryColor,
+            light: primaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFER),
+            dark: primaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFER),
+            textColor: getA11yTextColor(primaryColor),
+          },
+          secondary: {
+            regular: secondaryColor,
+            light: secondaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFER),
+            dark: secondaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFER),
+            textColor: getA11yTextColor(secondaryColor),
+          },
+          tertiary: {
+            regular: tertiaryColor,
+            light: tertiaryColor.lighten(COLOR_LIGHTEN_DARKEN_MODIFER),
+            dark: tertiaryColor.darken(COLOR_LIGHTEN_DARKEN_MODIFER),
+            textColor: getA11yTextColor(tertiaryColor),
+          },
+        };
+      }
+      return undefined;
+    },
+    [enterpriseConfig],
+  );
+
+  if (!isDefined(brandColors)) {
+    return null;
+  }
+
+  const colors = ['primary', 'secondary', 'tertiary'];
+  const styles = colors.map((colorName) => (
+    `
+      .brand-btn-${colorName} {
+        background-color: ${brandColors[colorName].regular.hex()} !important;
+        border-color: ${brandColors[colorName].regular.hex()} !important;
+        color: ${brandColors[colorName].textColor.hex()} !important;
+      }
+      .brand-btn-${colorName}:hover {
+        background-color: ${brandColors[colorName].dark.hex()} !important;
+        border-color: ${brandColors[colorName].dark.hex()} !important;
+      }
+      .brand-btn-${colorName}:focus:before {
+        border-color: ${brandColors[colorName].regular.hex()} !important;
+      }
+
+      .brand-btn-outline-${colorName} {
+        border-color: ${brandColors[colorName].regular.hex()} !important;
+        color: ${brandColors[colorName].regular.hex()} !important;
+      }
+      .brand-btn-outline-${colorName}:hover {
+        border-color: ${brandColors[colorName].dark.hex()} !important;
+        background-color: ${brandColors.white.mix(brandColors[colorName].light, COLOR_MIX_MODIFER).hex()} !important;
+      }
+      .brand-btn-outline-${colorName}:focus:before {
+        border-color: ${brandColors[colorName].regular.hex()} !important;
+      }
+
+      .brand-bg-${colorName} {
+        background-color: ${brandColors[colorName].regular.hex()} !important;
+        color: ${brandColors[colorName].textColor.hex()} !important;
+      }
+
+      .brand-border-${colorName} {
+        border-color: ${brandColors[colorName].regular.hex()} !important;
+      }
+    `
+  ));
+
+  return styles;
+};

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -5,16 +5,11 @@ export const isCourseEnded = endDate => moment(endDate) < moment();
 export const createArrayFromValue = (value) => {
   const values = [];
   switch (typeof value) {
-    case 'string':
-    case 'object':
-    case 'undefined':
-      values.push(value);
-      break;
     case 'array':
       values.concat(value);
       break;
     default:
-      // do nothing
+      values.push(value);
       break;
   }
   return values;

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -36,8 +36,6 @@ export const isDefinedAndNotNull = (value) => {
 };
 
 export const isDefinedAndNull = (value) => {
-  console.log('isDefinedAndNull', value);
   const values = createArrayFromValue(value);
-  console.log('isDefinedAndNull', values);
   return values.every(item => isDefined(item) && item === null);
 };

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,8 +1,43 @@
 import moment from 'moment';
 
-const isCourseEnded = (endDate) => moment(endDate) < moment();
+export const isCourseEnded = endDate => moment(endDate) < moment();
 
-export {
-  // eslint-disable-next-line import/prefer-default-export
-  isCourseEnded,
+export const createArrayFromValue = (value) => {
+  const values = [];
+  switch (typeof value) {
+    case 'string':
+    case 'object':
+    case 'undefined':
+      values.push(value);
+      break;
+    case 'array':
+      values.concat(value);
+      break;
+    default:
+      // do nothing
+      break;
+  }
+  return values;
+};
+
+export const isDefined = (value) => {
+  const values = createArrayFromValue(value);
+  return values.every(item => item !== undefined);
+};
+
+export const isNull = (value) => {
+  const values = createArrayFromValue(value);
+  return values.every(item => item === null);
+};
+
+export const isDefinedAndNotNull = (value) => {
+  const values = createArrayFromValue(value);
+  return values.every(item => isDefined(item) && item !== null);
+};
+
+export const isDefinedAndNull = (value) => {
+  console.log('isDefinedAndNull', value);
+  const values = createArrayFromValue(value);
+  console.log('isDefinedAndNull', values);
+  return values.every(item => isDefined(item) && item === null);
 };


### PR DESCRIPTION
This PR expands on the branding configurations that were already in place, and sets up the code base nicely for future remaining work on [ENT-2892](https://openedx.atlassian.net/browse/ENT-2892).

Instead of using inline styles for each UI element, pulling from `enterpriseConfig` in `AppContext`, we can utilize `react-helmet` to inject `<styles>` into the `<head>`. These styles include CSS overrides for `background-color`, `color`, and `border-color`. For example:
* A button that should have the primary brand background color: `<button className="btn btn-primary brand-btn-primary"`
* A banner that should have a secondary brand background color: `<div className="brand-bg-secondary" />`

This PR also includes logic to create versions of each custom color (i.e., primary, secondary, tertiary) for darker/lighter variations, as well as to dynamically determine the appropriate text color to use if overriding the background color to ensure good contrast, e.g. white text on a black background, or dark text on a light blue background.

_Note: I will add tests in a follow-up PR._