### PR TITLE
fix an issue related to the loading experience for the Search UI

### DIFF
--- a/src/components/search/SearchResults.jsx
+++ b/src/components/search/SearchResults.jsx
@@ -59,6 +59,20 @@ const SearchResults = ({
     [nbHits, query],
   );
 
+  const HitComponent = useMemo(
+    () => {
+      if (isSearchStalled) {
+        return SearchCourseCard.Skeleton;
+      }
+      return SearchCourseCard;
+    },
+    [isSearchStalled],
+  );
+
+  const isSearchResolvedWithNonNullNbHits = useMemo(
+    () => !isSearchStalled && isDefinedAndNotNull(nbHits),
+  );
+
   return (
     <div className="search-results container-fluid my-5">
       <>
@@ -67,11 +81,11 @@ const SearchResults = ({
             {isSearchStalled && (
               <Skeleton className="h2 d-block mb-3" width={240} />
             )}
-            {!isSearchStalled && nbHits > 0 && (
+            {isSearchResolvedWithNonNullNbHits && (
               <>Courses</>
             )}
           </h2>
-          {!isSearchStalled && nbHits > 0 && (
+          {isSearchResolvedWithNonNullNbHits && (
             <SearchPagination
               defaultRefinement={page}
               maxPagesDisplayed={5}
@@ -90,14 +104,14 @@ const SearchResults = ({
             </div>
           </>
         )}
-        {!isSearchStalled && nbHits > 0 && (
-          <>
-            <div className="lead mb-4">{resultsHeading}</div>
-            <Hits hitComponent={SearchCourseCard} />
-            <div className="d-flex justify-content-center">
-              <SearchPagination defaultRefinement={page} />
-            </div>
-          </>
+        {isSearchResolvedWithNonNullNbHits && (
+          <div className="lead mb-4">{resultsHeading}</div>
+        )}
+        <Hits hitComponent={HitComponent} />
+        {isSearchResolvedWithNonNullNbHits && (
+          <div className="d-flex justify-content-center">
+            <SearchPagination defaultRefinement={page} />
+          </div>
         )}
         {!isSearchStalled && nbHits === 0 && (
           <SearchNoResults />

--- a/src/components/search/styles/FacetList.scss
+++ b/src/components/search/styles/FacetList.scss
@@ -36,7 +36,10 @@
 
       .dropdown-item {
         padding-left: 30px;
-        white-space: break-spaces;
+        &:active {
+          background-color: unset;
+          color: unset;
+        }
       }
     }
   }

--- a/src/components/search/styles/MobileSearchFilters.scss
+++ b/src/components/search/styles/MobileSearchFilters.scss
@@ -60,9 +60,5 @@
       border: none;
       @extend .border-bottom;
     }
-
-    .dropdown-item {
-      padding-left: 30px;
-    }
   }
 }


### PR DESCRIPTION
When paginating through the courses, when the next page is loading, the search results currently flash the first page of results before showing the new results, where I'd expect it to be showing the course card loading state instead. This PR addresses this issue by ensuring the loading states of the course cards appear during pagination.