### PR TITLE
fix course sidebar null effort bug

### DIFF
--- a/src/components/course/CourseSidebar.jsx
+++ b/src/components/course/CourseSidebar.jsx
@@ -14,7 +14,7 @@ import { CourseContext } from './CourseContextProvider';
 import CourseSidebarListItem from './CourseSidebarListItem';
 import CourseAssociatedPrograms from './CourseAssociatedPrograms';
 
-import { isDefinedAndNotNull } from '../../utils/common';
+import { isDefinedAndNotNull, hasTruthyValue } from '../../utils/common';
 import {
   useCourseSubjects,
   useCoursePartners,
@@ -37,14 +37,14 @@ export default function CourseSidebar() {
       <ul className="pl-0 mb-5 course-details-sidebar">
         {isDefinedAndNotNull(activeCourseRun) && (
           <>
-            {isDefinedAndNotNull(activeCourseRun.weeksToComplete) && (
+            {hasTruthyValue(activeCourseRun.weeksToComplete) && (
               <CourseSidebarListItem
                 icon={faClock}
                 label="Length"
                 content={`${weeksToComplete} ${weeksLabel}`}
               />
             )}
-            {isDefinedAndNotNull([activeCourseRun.minEffort, activeCourseRun.maxEffort]) && (
+            {hasTruthyValue([activeCourseRun.minEffort, activeCourseRun.maxEffort]) && (
               <CourseSidebarListItem
                 icon={faTachometerAlt}
                 label="Effort"

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -32,3 +32,8 @@ export const isDefinedAndNull = (value) => {
   const values = createArrayFromValue(value);
   return values.every(item => isDefined(item) && isNull(item));
 };
+
+export const hasTruthyValue = (value) => {
+  const values = createArrayFromValue(value);
+  return values.every(item => !!item);
+};

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -4,14 +4,12 @@ export const isCourseEnded = endDate => moment(endDate) < moment();
 
 export const createArrayFromValue = (value) => {
   const values = [];
-  switch (typeof value) {
-    case 'array':
-      values.concat(value);
-      break;
-    default:
-      values.push(value);
-      break;
+
+  if (Array.isArray(value)) {
+    return value;
   }
+
+  values.push(value);
   return values;
 };
 
@@ -27,10 +25,10 @@ export const isNull = (value) => {
 
 export const isDefinedAndNotNull = (value) => {
   const values = createArrayFromValue(value);
-  return values.every(item => isDefined(item) && item !== null);
+  return values.every(item => isDefined(item) && !isNull(item));
 };
 
 export const isDefinedAndNull = (value) => {
   const values = createArrayFromValue(value);
-  return values.every(item => isDefined(item) && item === null);
+  return values.every(item => isDefined(item) && isNull(item));
 };

--- a/src/utils/tests/common.test.js
+++ b/src/utils/tests/common.test.js
@@ -2,6 +2,7 @@ import {
   isDefinedAndNotNull,
   createArrayFromValue,
   isDefinedAndNull,
+  hasTruthyValue,
 } from '../common';
 
 function assertTestCaseEquals(testCase, expectedValue) {
@@ -70,6 +71,28 @@ describe('isDefinedAndNull', () => {
 
   it('returns false when passed an array with no nulls', () => {
     const result = isDefinedAndNull(['test', 1]);
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('hasTruthyValue', () => {
+  it('returns true when passed a non-empty string', () => {
+    const result = hasTruthyValue('test');
+    expect(result).toBeTruthy();
+  });
+
+  it('returns true when passed an array with no nulls', () => {
+    const result = hasTruthyValue(['test', 1]);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns false when passed an array with 1 null', () => {
+    const result = hasTruthyValue(['test', null]);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false when passed an array with 1 empty string', () => {
+    const result = hasTruthyValue(['']);
     expect(result).toBeFalsy();
   });
 });

--- a/src/utils/tests/common.test.js
+++ b/src/utils/tests/common.test.js
@@ -1,0 +1,75 @@
+import {
+  isDefinedAndNotNull,
+  createArrayFromValue,
+  isDefinedAndNull,
+} from '../common';
+
+function assertTestCaseEquals(testCase, expectedValue) {
+  const result = createArrayFromValue(testCase);
+  expect(result).toEqual(expectedValue);
+}
+
+describe('createArrayFromValue', () => {
+  it('handles array value', () => {
+    const testCase = [null, null];
+    assertTestCaseEquals(testCase, testCase);
+  });
+
+  it('handles other values', () => {
+    let testCase = 2;
+    assertTestCaseEquals(testCase, [testCase]);
+
+    testCase = { test: 'key' };
+    assertTestCaseEquals(testCase, [testCase]);
+
+    testCase = 2;
+    assertTestCaseEquals(testCase, [testCase]);
+
+    testCase = undefined;
+    assertTestCaseEquals(testCase, [testCase]);
+  });
+});
+
+describe('isDefinedAndNotNull', () => {
+  it('returns false when passed a null', () => {
+    const result = isDefinedAndNotNull(null);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false when passed an array of nulls', () => {
+    const result = isDefinedAndNotNull([null, null]);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false when passed an array with 1 null', () => {
+    const result = isDefinedAndNotNull(['test', null]);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns true when passed an array with no nulls', () => {
+    const result = isDefinedAndNotNull(['test', 1]);
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('isDefinedAndNull', () => {
+  it('returns true when passed a null', () => {
+    const result = isDefinedAndNull(null);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns true when passed an array of nulls', () => {
+    const result = isDefinedAndNull([null, null]);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns false when passed an array with 1 null', () => {
+    const result = isDefinedAndNull(['test', null]);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false when passed an array with no nulls', () => {
+    const result = isDefinedAndNull(['test', 1]);
+    expect(result).toBeFalsy();
+  });
+});


### PR DESCRIPTION
This PR fixes the conditional logic to no longer render the "Effort" details if either of the `minEffort` or `maxEffort` fields are `null` in order to address this bug. 

<img src="https://user-images.githubusercontent.com/2828721/86468317-3337c300-bd05-11ea-8593-6c23a091a242.png" width="400" />
