### PR TITLE
display partner logo from algolia

### DIFF
--- a/src/components/search/SearchCourseCard.jsx
+++ b/src/components/search/SearchCourseCard.jsx
@@ -45,10 +45,6 @@ const SearchCourseCard = ({ hit, isLoading }) => {
     [course],
   );
 
-  // FIXME: temporarily using the course image for "How to Learn Online" until Algolia is
-  // aware of the correct course card images to be using.
-  const temporaryDefaultCardImage = 'https://prod-discovery.edx-cdn.org/media/course/image/0e575a39-da1e-4e33-bb3b-e96cc6ffc58e-8372a9a276c1.png';
-
   return (
     <div
       className="discovery-card mb-4"
@@ -67,7 +63,7 @@ const SearchCourseCard = ({ hit, isLoading }) => {
           ) : (
             <img
               className="card-img-top"
-              src={course.cardImageUrl || temporaryDefaultCardImage}
+              src={course.cardImageUrl}
               alt=""
             />
           )}
@@ -77,10 +73,9 @@ const SearchCourseCard = ({ hit, isLoading }) => {
             )}
             {!isLoading && partnerDetails.primaryPartner && partnerDetails.showPartnerLogo && (
               <img
-                // FIXME: hardcoding the edX partner logo for now until Algolia is aware of partner logos
-                src="https://prod-discovery.edx-cdn.org/organization/logos/4f8cb2c9-589b-4d1e-88c1-b01a02db3a9c-2b8dd916262f.png"
+                src={partnerDetails.primaryPartner.logoImgUrl}
                 className="partner-logo"
-                alt={partnerDetails.primaryPartner}
+                alt={partnerDetails.primaryPartner.name}
               />
             )}
           </div>
@@ -101,7 +96,7 @@ const SearchCourseCard = ({ hit, isLoading }) => {
                 {course.partners.length > 0 && (
                   <p className="partner text-muted m-0">
                     <Truncate lines={1} trimWhitespace>
-                      {course.partners.join(', ')}
+                      {course.partners.map(partner => partner.name).join(', ')}
                     </Truncate>
                   </p>
                 )}

--- a/src/components/search/data/tests/constants.js
+++ b/src/components/search/data/tests/constants.js
@@ -14,3 +14,4 @@ export const FACET_ATTRIBUTES = {
 };
 
 export const TEST_ENTERPRISE_SLUG = 'test-enterprise-slug';
+export const TEST_IMAGE_URL = 'https://fake.image';

--- a/src/components/search/tests/SearchCourseCard.test.jsx
+++ b/src/components/search/tests/SearchCourseCard.test.jsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/extend-expect';
 import SearchCourseCard from '../SearchCourseCard';
 
 import { renderWithRouter } from '../../../utils/tests';
-import { TEST_ENTERPRISE_SLUG } from '../data/tests/constants';
+import { TEST_ENTERPRISE_SLUG, TEST_IMAGE_URL } from '../data/tests/constants';
 
 jest.mock('react-truncate', () => ({
   __esModule: true,
@@ -32,14 +32,17 @@ const SearchCourseCardWithAppContext = (props) => (
 const TEST_COURSE_KEY = 'test-course-key';
 const TEST_TITLE = 'Test Title';
 const TEST_CARD_IMG_URL = 'http://fake.image';
-const TEST_PARTNER_NAME = 'Partner Name';
+const TEST_PARTNER = {
+  name: 'Partner Name',
+  logoImgUrl: TEST_IMAGE_URL,
+};
 
 const defaultProps = {
   hit: {
     key: TEST_COURSE_KEY,
     title: TEST_TITLE,
     card_image_url: TEST_CARD_IMG_URL,
-    partners: [TEST_PARTNER_NAME],
+    partners: [TEST_PARTNER],
   },
 };
 
@@ -53,13 +56,13 @@ describe('<SearchCourseCard />', () => {
     const { container } = renderWithRouter(<SearchCourseCardWithAppContext {...defaultProps} />);
 
     expect(screen.getByText(TEST_TITLE)).toBeInTheDocument();
-    expect(screen.getByAltText(TEST_PARTNER_NAME)).toBeInTheDocument();
+    expect(screen.getByAltText(TEST_PARTNER.name)).toBeInTheDocument();
 
     expect(container.querySelector('.discovery-card > a')).toHaveAttribute(
       'href',
       `/${TEST_ENTERPRISE_SLUG}/course/${TEST_COURSE_KEY}`,
     );
-    expect(container.querySelector('p.partner')).toHaveTextContent(TEST_PARTNER_NAME);
+    expect(container.querySelector('p.partner')).toHaveTextContent(TEST_PARTNER.name);
     expect(container.querySelector('.card-img-top')).toHaveAttribute('src', TEST_CARD_IMG_URL);
   });
 


### PR DESCRIPTION
Ticket: https://openedx.atlassian.net/browse/ENT-3061

The Algolia search index currently does not contain the partner logo; [this PR](https://github.com/edx/enterprise-catalog/pull/150) addresses this issue by adding it to the course records along with the correct course card image.

This PR updates the code to reflect these changes,