### PR TITLE
prevent JS error on Search page

### DIFF
--- a/src/components/search/SearchCourseCard.jsx
+++ b/src/components/search/SearchCourseCard.jsx
@@ -6,6 +6,8 @@ import Skeleton from 'react-loading-skeleton';
 import { AppContext } from '@edx/frontend-platform/react';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
+import { isDefinedAndNotNull } from '../../utils/common';
+
 import './styles/SearchCourseCard.scss';
 
 const SearchCourseCard = ({ hit, isLoading }) => {
@@ -33,7 +35,7 @@ const SearchCourseCard = ({ hit, isLoading }) => {
 
   const partnerDetails = useMemo(
     () => {
-      if (!Object.keys(course).length) {
+      if (!Object.keys(course).length || !isDefinedAndNotNull(course.partners)) {
         return {};
       }
 


### PR DESCRIPTION
Noticed this JS error on the "Search" UI: 

![image](https://user-images.githubusercontent.com/2828721/86941094-877de100-c111-11ea-8758-666243ef35c6.png)

Turns out it was due to missing data from Algolia (see https://github.com/edx/enterprise-catalog/pull/155 for context / a fix). Even though the linked PR should address this issue, this particular PR makes the logic a bit more resilient to not error again if/when the `partners` field is missing from an Algolia object.
