### PR TITLE
Update EnrollButton to link to DSC for licenses 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An enterprise portal will need a couple of roles: The Enterprise customer, and a
 
 Next we will setup a `test-enterprise` customer who will have learners associated with it (Details at [The Enterprise management commands](https://github.com/edx/edx-enterprise/blob/master/enterprise/management/commands/seed_enterprise_devstack_data.py#L47)):
 
- - Ensure the Enterprise Integration flag is enabled in devstack [see this link](https://github.com/edx/edx-platform/blob/master/lms/envs/devstack.py#L326). Set the flag `ENABLE_ENTERPRISE_INTEGRATION` to True
+ - Ensure the Enterprise Integration flag is enabled in devstack [see this link](https://github.com/edx/edx-platform/blob/0e2b612c1fb4f3e385f3004801aa5b5ed0221eda/lms/envs/devstack.py#L331). Set the flag `ENABLE_ENTERPRISE_INTEGRATION` to True if it isn't already
  - From the devstack directory, restart lms using `make lms-restart` for applying changes
  - Seed test data:
    - Go into the lms shell:
@@ -74,7 +74,7 @@ In this section you will:
 * Log out of any users if you logged in previously, or use a new incognito window, and browse to http://localhost:8734/test-enterprise
 * The `test-enterprise`, you will note, is the slug for this enterprise customer
 * Login as a learner, using `enterprise_learner_1@example.com` account, you may need to re-browse to page http://localhost:8734/test-enterprise/
-* You can now go to 'Explore Courses' and enroll in courses
+* You can now go to 'Find a Course' and enroll in courses
 
 You are now in the Learner portal for the enterpriser customer `Test Enterprise`, as a learner!
 

--- a/src/components/course/EnrollButton.jsx
+++ b/src/components/course/EnrollButton.jsx
@@ -45,7 +45,9 @@ export default function EnrollButton() {
     license_uuid: subscriptionLicense.uuid,
     course_id: key,
     enterprise_customer_uuid: enterpriseConfig.uuid,
-    next: `${process.env.LMS_BASE_URL}/dashboard`,
+    // TODO: this next behavior mimics the existing B2C enrollment flow. we will want to redirect learners to the basket
+    // flow instead of the track selection page.
+    next: `${process.env.LMS_BASE_URL}/course_modes/choose/${key}`,
     failure_url: global.location,
   };
   const licenseEnrollmentUrl = `${process.env.LMS_BASE_URL}/enterprise/grant_data_sharing_permissions/?${qs.stringify(enrollOptions)}`;

--- a/src/components/course/EnrollButton.jsx
+++ b/src/components/course/EnrollButton.jsx
@@ -48,6 +48,7 @@ export default function EnrollButton() {
     failure_url: global.location,
   };
   const licenseEnrollmentUrl = `${process.env.LMS_BASE_URL}/enterprise/grant_data_sharing_permissions/?${qs.stringify(enrollOptions)}`;
+  const enrollLinkClass = 'btn btn-success btn-block rounded-0 py-2';
 
   const isCourseStarted = useMemo(
     () => hasCourseStarted(start),
@@ -104,7 +105,7 @@ export default function EnrollButton() {
     if (!isUserEnrolled && isEnrollable) {
       return (
         <a
-          className="btn btn-success btn-block rounded-0 py-2"
+          className={enrollLinkClass}
           href={licenseEnrollmentUrl}
         >
           {renderButtonLabel()}
@@ -123,7 +124,7 @@ export default function EnrollButton() {
     if (isUserEnrolled) {
       return (
         <a
-          className="btn btn-success btn-block rounded-0 py-2"
+          className={enrollLinkClass}
           href={isCourseStarted
             ? `${process.env.LMS_BASE_URL}/courses/${key}/info`
             : `${process.env.LMS_BASE_URL}/dashboard`}

--- a/src/components/course/EnrollButton.jsx
+++ b/src/components/course/EnrollButton.jsx
@@ -3,6 +3,7 @@ import React, {
 } from 'react';
 import moment from 'moment';
 import qs from 'query-string';
+import { Link } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Button } from '@edx/paragon';
 
@@ -122,15 +123,24 @@ export default function EnrollButton() {
     }
 
     if (isUserEnrolled) {
+      if (isCourseStarted) {
+        return (
+          <a
+            className={enrollLinkClass}
+            href={`${process.env.LMS_BASE_URL}/courses/${key}/info`}
+          >
+            {renderButtonLabel()}
+          </a>
+        );
+      }
+
       return (
-        <a
+        <Link
           className={enrollLinkClass}
-          href={isCourseStarted
-            ? `${process.env.LMS_BASE_URL}/courses/${key}/info`
-            : `${process.env.LMS_BASE_URL}/dashboard`}
+          to={`/${enterpriseConfig.slug}`}
         >
           {renderButtonLabel()}
-        </a>
+        </Link>
       );
     }
 

--- a/src/components/course/EnrollButton.jsx
+++ b/src/components/course/EnrollButton.jsx
@@ -45,9 +45,7 @@ export default function EnrollButton() {
     license_uuid: subscriptionLicense.uuid,
     course_id: key,
     enterprise_customer_uuid: enterpriseConfig.uuid,
-    // TODO: this next behavior mimics the existing B2C enrollment flow. we will want to redirect learners to the basket
-    // flow instead of the track selection page.
-    next: `${process.env.LMS_BASE_URL}/course_modes/choose/${key}`,
+    next: `${process.env.LMS_BASE_URL}/courses/${key}/course`,
     failure_url: global.location,
   };
   const licenseEnrollmentUrl = `${process.env.LMS_BASE_URL}/enterprise/grant_data_sharing_permissions/?${qs.stringify(enrollOptions)}`;

--- a/src/components/enterprise-user-subsidy/UserSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidy.jsx
@@ -34,7 +34,7 @@ const UserSubsidy = ({ children }) => {
         hasAccessToPortal = false;
       }
 
-      return { hasAccessToPortal };
+      return { hasAccessToPortal, subscriptionLicense };
     },
     [subscriptionLicense],
   );


### PR DESCRIPTION
Link to the Data Sharing Consent (DSC) view for learners enrolling with
a license.
Note that this commit assumes that the user has access to the content
through their subscription and is using a license to enroll. The logic
around calling the license subsidy view will be implemented by:
https://openedx.atlassian.net/browse/ENT-2685. Additionally, this
enrollment url will need to be updated in the future to support codes
and offers.