### PR TITLE
fix external links to prospectus from Course page

### DIFF
--- a/src/components/course/CourseAssociatedPrograms.jsx
+++ b/src/components/course/CourseAssociatedPrograms.jsx
@@ -28,7 +28,7 @@ export default function CourseAssociatedPrograms() {
               </div>
             </div>
             <div className="col">
-              <a href={`${process.env.MARKETING_SITE_BASE_URL}/${program.marketingUrl}`}>
+              <a href={program.marketingUrl}>
                 {program.title}
               </a>
             </div>

--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -62,7 +62,7 @@ export default function CourseHeader() {
                 {partners.map(partner => (
                   <a
                     className="d-inline-block mr-4"
-                    href={partner.fullUrl}
+                    href={partner.marketingUrl}
                     key={partner.key}
                   >
                     <img

--- a/src/components/course/CourseSidebar.jsx
+++ b/src/components/course/CourseSidebar.jsx
@@ -64,7 +64,7 @@ export default function CourseSidebar() {
             label={institutionLabel}
             content={partners.map(partner => (
               <span key={partner.key} className="d-block">
-                <a href={partner.fullUrl}>
+                <a href={partner.marketingUrl}>
                   {partner.key}
                 </a>
               </span>

--- a/src/components/course/CreatedBy.jsx
+++ b/src/components/course/CreatedBy.jsx
@@ -21,13 +21,13 @@ export default function CreatedBy() {
       {partners.length > 0 && (
         <div className="row no-gutters mt-3">
           {partners.map(partner => (
-            <div className="col-lg-6 mb-3" key={partner.fullUrl}>
+            <div className="col-lg-6 mb-3" key={partner.marketingUrl}>
               <div className="mb-2">
-                <a href={partner.fullUrl} aria-hidden="true" tabIndex="-1">
+                <a href={partner.marketingUrl} aria-hidden="true" tabIndex="-1">
                   <img src={partner.logoImageUrl} alt={`${partner.name} logo`} />
                 </a>
               </div>
-              <a href={partner.fullUrl} className="text-underline">{partner.name}</a>
+              <a href={partner.marketingUrl} className="text-underline">{partner.name}</a>
             </div>
           ))}
         </div>

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -33,10 +33,10 @@ export function useAllCourseData({ courseKey, enterpriseConfig }) {
 
 export function useCourseSubjects(course) {
   const [subjects, setSubjects] = useState([]);
-  const [primarySubject, setPrimarySubject] = useState(undefined);
+  const [primarySubject, setPrimarySubject] = useState(null);
 
   useEffect(() => {
-    if (course && course.subjects) {
+    if (course?.subjects) {
       setSubjects(course.subjects);
       if (course.subjects.length > 0) {
         const newSubject = {
@@ -56,13 +56,9 @@ export function useCoursePartners(course) {
   const [label, setLabel] = useState(undefined);
 
   useEffect(() => {
-    if (course && course.owners) {
-      const newOwners = course.owners.map(owner => ({
-        ...owner,
-        fullUrl: `${process.env.MARKETING_SITE_BASE_URL}/${owner.marketingUrl}`,
-      }));
-      setPartners(newOwners);
-      if (newOwners.length > 1) {
+    if (course?.owners) {
+      setPartners(course.owners);
+      if (course.owners.length > 1) {
         setLabel('Institutions');
       } else {
         setLabel('Institution');


### PR DESCRIPTION
Right now, there are some links that are double-prefixed with the marketing site's hostname (e.g., `https://stage.edx.org/https://stage.edx.org/some-link`). This PR fixes that to use the full absolute URL we get from the API instead of prefixing it with a hostname from configuration.