### PR TITLE
Add license activation page

### DIFF
--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -7,6 +7,7 @@ import { DashboardPage } from '../dashboard';
 import NotFoundPage from '../NotFoundPage';
 import { CoursePage } from '../course';
 import { SearchPage } from '../search';
+import { LicenseActivationPage } from '../license-activation';
 
 import store from '../../store';
 
@@ -24,6 +25,7 @@ export default function App() {
         <PageRoute exact path="/:enterpriseSlug" component={DashboardPage} />
         <PageRoute exact path="/:enterpriseSlug/search" component={SearchPage} />
         <PageRoute exact path="/:enterpriseSlug/course/:courseKey" component={CoursePage} />
+        <PageRoute exact path="/:enterpriseSlug/licenses/:activationKey/activate" component={LicenseActivationPage} />
         <PageRoute path="*" component={NotFoundPage} />
       </Switch>
     </AppProvider>

--- a/src/components/enterprise-user-subsidy/SubscriptionSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/SubscriptionSubsidy.jsx
@@ -4,8 +4,9 @@ import { Redirect, useRouteMatch } from 'react-router-dom';
 import { StatusAlert } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
-import { useRenderContactHelpText } from './data/hooks';
 import { LICENSE_STATUS } from './data/constants';
+
+import { useRenderContactHelpText } from '../../utils/hooks';
 
 const SubscriptionSubsidy = ({ subscriptionLicense }) => {
   const { enterpriseConfig } = useContext(AppContext);

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
@@ -6,6 +6,7 @@ import { isNull } from '../../../utils/common';
 import { LICENSE_STATUS } from './constants';
 import { fetchSubscriptionLicensesForUser } from './service';
 
+// eslint-disable-next-line import/prefer-default-export
 export function useSubscriptionLicenseForUser(subscriptionPlan) {
   const [license, setLicense] = useState();
   const [isLoading, setIsLoading] = useState(true);
@@ -43,24 +44,4 @@ export function useSubscriptionLicenseForUser(subscriptionPlan) {
   }, [subscriptionPlan]);
 
   return [license, isLoading];
-}
-
-export function useRenderContactHelpText(enterpriseConfig) {
-  const renderContactHelpText = useCallback(
-    () => {
-      const { contactEmail } = enterpriseConfig;
-      const message = 'reach out to your organization\'s edX administrator';
-      if (contactEmail) {
-        return (
-          <a className="text-underline" href={`mailto:${contactEmail}`}>
-            {message}
-          </a>
-        );
-      }
-      return message;
-    },
-    [enterpriseConfig],
-  );
-
-  return renderContactHelpText;
 }

--- a/src/components/license-activation/LicenseActivation.jsx
+++ b/src/components/license-activation/LicenseActivation.jsx
@@ -6,7 +6,8 @@ import { StatusAlert } from '@edx/paragon';
 
 import { LoadingSpinner } from '../loading-spinner';
 import { useLicenseActivation } from './data/hooks';
-import { useRenderContactHelpText } from '../enterprise-user-subsidy/data/hooks';
+
+import { useRenderContactHelpText } from '../../utils/hooks';
 
 export default function LicenseActivation() {
   const { activationKey } = useParams();
@@ -21,26 +22,28 @@ export default function LicenseActivation() {
     );
   }
 
+  const PAGE_TITLE = `License Activation - ${enterpriseConfig.name}`;
   if (activationError) {
     return (
-      <div className="container-fluid mt-3">
-        <StatusAlert
-          alertType="danger"
-          className="mb"
-          dialog={(
-            <>
-              An unexpected error occurred while activating your license.
-              Please {renderContactHelpText()} for assistance.
-            </>
-          )}
-          dismissible={false}
-          open
-        />
-      </div>
+      <>
+        <Helmet title={PAGE_TITLE} />
+        <div className="container-fluid mt-3">
+          <StatusAlert
+            alertType="danger"
+            dialog={(
+              <>
+                An unexpected error occurred while activating your license.
+                Please {renderContactHelpText()} for assistance.
+              </>
+            )}
+            dismissible={false}
+            open
+          />
+        </div>
+      </>
     );
   }
 
-  const PAGE_TITLE = `License Activation - ${enterpriseConfig.name}`;
   const LOADING_MESSAGE = 'Your enterprise license is being activated! You will be automatically redirected to your organization\'s learner portal shortly.';
 
   return (

--- a/src/components/license-activation/LicenseActivation.jsx
+++ b/src/components/license-activation/LicenseActivation.jsx
@@ -9,6 +9,8 @@ import { useLicenseActivation } from './data/hooks';
 
 import { useRenderContactHelpText } from '../../utils/hooks';
 
+export const LOADING_MESSAGE = 'Your enterprise license is being activated! You will be automatically redirected to your organization\'s learner portal shortly.';
+
 export default function LicenseActivation() {
   const { activationKey } = useParams();
   const { enterpriseConfig } = useContext(AppContext);
@@ -44,13 +46,11 @@ export default function LicenseActivation() {
     );
   }
 
-  const LOADING_MESSAGE = 'Your enterprise license is being activated! You will be automatically redirected to your organization\'s learner portal shortly.';
-
   return (
     <>
       <Helmet title={PAGE_TITLE} />
       <div className="container-fluid py-5">
-        {LOADING_MESSAGE}
+        <p>{LOADING_MESSAGE}</p>
         <LoadingSpinner screenReaderText={LOADING_MESSAGE} />
       </div>
     </>

--- a/src/components/license-activation/LicenseActivation.jsx
+++ b/src/components/license-activation/LicenseActivation.jsx
@@ -1,0 +1,55 @@
+import React, { useContext } from 'react';
+import { Redirect, useParams } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import { AppContext } from '@edx/frontend-platform/react';
+import { StatusAlert } from '@edx/paragon';
+
+import { LoadingSpinner } from '../loading-spinner';
+import { useLicenseActivation } from './data/hooks';
+import { useRenderContactHelpText } from '../enterprise-user-subsidy/data/hooks';
+
+export default function LicenseActivation() {
+  const { activationKey } = useParams();
+  const { enterpriseConfig } = useContext(AppContext);
+  const renderContactHelpText = useRenderContactHelpText(enterpriseConfig);
+
+  const [activationSuccess, activationError] = useLicenseActivation(activationKey);
+
+  if (activationSuccess) {
+    return (
+      <Redirect to={`/${enterpriseConfig.slug}`} />
+    );
+  }
+
+  if (activationError) {
+    return (
+      <div className="container-fluid mt-3">
+        <StatusAlert
+          alertType="danger"
+          className="mb"
+          dialog={(
+            <>
+              An unexpected error occurred while activating your license.
+              Please {renderContactHelpText()} for assistance.
+            </>
+          )}
+          dismissible={false}
+          open
+        />
+      </div>
+    );
+  }
+
+  const PAGE_TITLE = `License Activation - ${enterpriseConfig.name}`;
+  const LOADING_MESSAGE = 'Your enterprise license is being activated! You will be automatically redirected to your organization\'s learner portal shortly.';
+
+  return (
+    <>
+      <Helmet title={PAGE_TITLE} />
+      <div className="container-fluid py-5">
+        {LOADING_MESSAGE}
+        <LoadingSpinner screenReaderText={LOADING_MESSAGE} />
+      </div>
+    </>
+  );
+}

--- a/src/components/license-activation/LicenseActivationPage.jsx
+++ b/src/components/license-activation/LicenseActivationPage.jsx
@@ -5,7 +5,7 @@ import { EnterpriseBanner } from '../enterprise-banner';
 import { Layout } from '../layout';
 import LicenseActivation from './LicenseActivation';
 
-const ActivationPage = () => (
+const LicenseActivationPage = () => (
   <EnterprisePage>
     <Layout>
       <EnterpriseBanner />
@@ -14,4 +14,4 @@ const ActivationPage = () => (
   </EnterprisePage>
 );
 
-export default ActivationPage;
+export default LicenseActivationPage;

--- a/src/components/license-activation/LicenseActivationPage.jsx
+++ b/src/components/license-activation/LicenseActivationPage.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { EnterprisePage } from '../enterprise-page';
+import { EnterpriseBanner } from '../enterprise-banner';
+import { Layout } from '../layout';
+import LicenseActivation from './LicenseActivation';
+
+const ActivationPage = () => (
+  <EnterprisePage>
+    <Layout>
+      <EnterpriseBanner />
+      <LicenseActivation />
+    </Layout>
+  </EnterprisePage>
+);
+
+export default ActivationPage;

--- a/src/components/license-activation/data/hooks.js
+++ b/src/components/license-activation/data/hooks.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { activateLicense } from './service';
+
+// eslint-disable-next-line import/prefer-default-export
+export function useLicenseActivation(activationKey) {
+  const [activationSuccess, setActivationSuccess] = useState();
+  const [activationError, setActivationError] = useState();
+
+  useEffect(() => {
+    activateLicense(activationKey)
+      .then(() => {
+        setActivationSuccess(true);
+        setActivationError(false);
+      })
+      .catch((error) => {
+        logError(new Error(error));
+        setActivationError(true);
+        setActivationSuccess(false);
+      });
+  }, [activationKey]);
+
+  return [activationSuccess, activationError];
+}

--- a/src/components/license-activation/data/hooks.js
+++ b/src/components/license-activation/data/hooks.js
@@ -5,8 +5,8 @@ import { activateLicense } from './service';
 
 // eslint-disable-next-line import/prefer-default-export
 export function useLicenseActivation(activationKey) {
-  const [activationSuccess, setActivationSuccess] = useState();
-  const [activationError, setActivationError] = useState();
+  const [activationSuccess, setActivationSuccess] = useState(false);
+  const [activationError, setActivationError] = useState(false);
 
   useEffect(() => {
     activateLicense(activationKey)

--- a/src/components/license-activation/data/service.js
+++ b/src/components/license-activation/data/service.js
@@ -1,0 +1,10 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import qs from 'query-string';
+
+// eslint-disable-next-line import/prefer-default-export
+export function activateLicense(activationKey) {
+  const queryParams = { activation_key: activationKey };
+  const url = `${process.env.LICENSE_MANAGER_URL}/api/v1/license-activation/?${qs.stringify(queryParams)}`;
+
+  return getAuthenticatedHttpClient().post(url);
+}

--- a/src/components/license-activation/index.js
+++ b/src/components/license-activation/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as LicenseActivationPage } from './LicenseActivationPage';

--- a/src/components/license-activation/tests/LicenseActivation.test.jsx
+++ b/src/components/license-activation/tests/LicenseActivation.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { AppContext } from '@edx/frontend-platform/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import LicenseActivation, { LOADING_MESSAGE } from '../LicenseActivation';
+import { useLicenseActivation } from '../data/hooks';
+
+import { renderWithRouter } from '../../../utils/tests';
+
+jest.mock('../data/hooks');
+
+const TEST_ENTERPRISE_SLUG = 'test-enterprise-slug';
+const TEST_ACTIVATION_KEY = '00000000-0000-0000-0000-000000000000';
+const TEST_ROUTE = `/${TEST_ENTERPRISE_SLUG}/licenses/${TEST_ACTIVATION_KEY}/activate`;
+
+const LicenseActivationWithAppContext = () => (
+  <AppContext.Provider
+    value={{
+      enterpriseConfig: { slug: TEST_ENTERPRISE_SLUG, name: 'Test Enterprise' },
+    }}
+  >
+    <LicenseActivation />
+  </AppContext.Provider>
+);
+
+describe('LicenseActivation', () => {
+  beforeEach(() => {
+    useLicenseActivation.mockReset();
+  });
+
+  test('renders a loading message initially', async () => {
+    // For the initial state, there is no activation success or error
+    useLicenseActivation.mockReturnValue([false, false]);
+    const Component = <LicenseActivationWithAppContext />;
+    const { history } = renderWithRouter(Component, {
+      route: TEST_ROUTE,
+    });
+
+    // assert component is initially loading and displays the loading message as text and SR text
+    expect(screen.queryAllByText(LOADING_MESSAGE)).toHaveLength(2);
+
+    // assert we did NOT get redirected
+    expect(history.location.pathname).toEqual(TEST_ROUTE);
+  });
+
+  test('renders an error alert when there is an activation error', async () => {
+    useLicenseActivation.mockReturnValue([false, true]);
+    const Component = <LicenseActivationWithAppContext />;
+    const { history } = renderWithRouter(Component, {
+      route: TEST_ROUTE,
+    });
+
+    // assert an error alert appears
+    expect(screen.getByRole('alert')).toHaveClass('alert-danger');
+
+    // assert we did NOT get redirected
+    expect(history.location.pathname).toEqual(TEST_ROUTE);
+  });
+
+  test('redirects on activation success', async () => {
+    useLicenseActivation.mockReturnValue([true, false]);
+    const Component = <LicenseActivationWithAppContext />;
+    const { history } = renderWithRouter(Component, {
+      route: TEST_ROUTE,
+    });
+
+    // assert we were redirected to the dashboard
+    expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE_SLUG}`);
+  });
+});

--- a/src/components/login-redirect/LoginRedirect.jsx
+++ b/src/components/login-redirect/LoginRedirect.jsx
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import qs from 'query-string';
+import { useParams } from 'react-router-dom';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+
+/**
+ * This wrapper component redirects the requester to our proxy login view with additional query parameters if they are
+ * not already authenticated.
+ *
+ * @param {node} children The child nodes to render if there is an authenticated user.
+ */
+// TODO: Use this for all pages and remove requirement for authenticated users
+export default function LoginRedirect({ children }) {
+  const user = getAuthenticatedUser();
+
+  if (user) {
+    return children;
+  }
+
+  const { enterpriseSlug } = useParams();
+  const options = {
+    slug: enterpriseSlug,
+    next: global.location,
+  };
+  const proxyLoginUrl = `${process.env.LMS_BASE_URL}/enterprise/proxy_login/?${qs.stringify(options)}`;
+  global.location.assign(proxyLoginUrl);
+  return null;
+}
+
+LoginRedirect.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/login-redirect/LoginRedirect.jsx
+++ b/src/components/login-redirect/LoginRedirect.jsx
@@ -23,7 +23,7 @@ export default function LoginRedirect({ children }) {
     next: global.location,
   };
   const proxyLoginUrl = `${process.env.LMS_BASE_URL}/enterprise/proxy_login/?${qs.stringify(options)}`;
-  global.location.assign(proxyLoginUrl);
+  global.location.href = proxyLoginUrl;
   return null;
 }
 

--- a/src/components/login-redirect/index.js
+++ b/src/components/login-redirect/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as LoginRedirect } from './LoginRedirect';

--- a/src/components/login-redirect/tests/LoginRedirect.test.jsx
+++ b/src/components/login-redirect/tests/LoginRedirect.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+import '@testing-library/jest-dom/extend-expect';
+
+import LoginRedirect from '../LoginRedirect';
+
+import { renderWithRouter } from '../../../utils/tests';
+
+jest.mock('@edx/frontend-platform/auth');
+
+const TEST_ENTERPRISE_SLUG = 'test-enterprise-slug';
+
+const LoginRedirectWithChild = () => (
+  <LoginRedirect>
+    <span data-testid="did-i-render" />
+  </LoginRedirect>
+);
+describe('LoginRedirect', () => {
+  beforeEach(() => {
+    getAuthenticatedUser.mockReset();
+  });
+
+  test('renders children if the user is authenticated', async () => {
+    getAuthenticatedUser.mockReturnValue({ user: { email: 'test-user' } });
+    const Component = <LoginRedirectWithChild />;
+    const { history } = renderWithRouter(Component, {
+      route: `/${TEST_ENTERPRISE_SLUG}`,
+    });
+
+    // assert children are rendered
+    expect(screen.queryByTestId('did-i-render')).toBeInTheDocument();
+
+    // assert we did NOT get redirected
+    expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE_SLUG}`);
+  });
+
+  test('does not render children (due to redirect) if the user is not authenticated', async () => {
+    const Component = <LoginRedirectWithChild />;
+    renderWithRouter(Component, {
+      route: `/${TEST_ENTERPRISE_SLUG}`,
+    });
+
+    // assert children are not rendered
+    expect(screen.queryByTestId('did-i-render')).not.toBeInTheDocument();
+    // We don't test the redirect functionality explicitly as navigation is not currently supported by jsdom
+  });
+});

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,6 +26,9 @@ subscribe(APP_INIT_ERROR, (error) => {
 
 initialize({
   messages: [],
+  // We don't require authenticated users so that we can perform our own auth redirect to a proxy login that depends on
+  // the route, rather than the LMS like frontend-platform does.
+  // TODO: Switch require auth'd user to false (so the above comment is true) once https://openedx.atlassian.net/browse/ENT-3141 is done
   requireAuthenticatedUser: true,
   hydrateAuthenticatedUser: true,
 });

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 
 // eslint-disable-next-line import/prefer-default-export
 export const useWindowSize = () => {
@@ -26,3 +26,23 @@ export const useWindowSize = () => {
 
   return windowSize;
 };
+
+export function useRenderContactHelpText(enterpriseConfig) {
+  const renderContactHelpText = useCallback(
+    () => {
+      const { contactEmail } = enterpriseConfig;
+      const message = 'reach out to your organization\'s edX administrator';
+      if (contactEmail) {
+        return (
+          <a className="text-underline" href={`mailto:${contactEmail}`}>
+            {message}
+          </a>
+        );
+      }
+      return message;
+    },
+    [enterpriseConfig],
+  );
+
+  return renderContactHelpText;
+}


### PR DESCRIPTION
Also adds a login redirect component that redirects any unauthenticated
learners to our new (yet to be implemented) proxy login view in edx
enterprise. The login redirect component is currently not used anywhere
but will be enabled in a follow up PR once the proxy login view is
implemented by https://openedx.atlassian.net/browse/ENT-3141.

ENT-3097