### PR TITLE
Remove 'magic strings' from the code

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -21,6 +21,13 @@ import * as actions from './data/actions';
 const SAVED_FOR_LATER_COURSES_SECTION_SUBTITLE = `This section contains both the courses you have completed
   in the past and courses that have been voluntarily removed from your "In Progress" list.`;
 
+export const COURSE_SECTION_TITLES = {
+  inProgress: 'My courses in progress',
+  upcoming: 'Upcoming courses',
+  completed: 'Completed courses',
+  savedForLater: 'Courses saved for later',
+};
+
 export class CourseEnrollments extends Component {
   componentDidMount() {
     const {
@@ -145,23 +152,23 @@ export class CourseEnrollments extends Component {
         */}
         {!this.hasCourseRuns() && children}
         <CourseSection
-          title="My courses in progress"
+          title={COURSE_SECTION_TITLES.inProgress}
           component={InProgressCourseCard}
           courseRuns={courseRuns.in_progress}
         />
         <CourseSection
-          title="Upcoming courses"
+          title={COURSE_SECTION_TITLES.upcoming}
           component={UpcomingCourseCard}
           courseRuns={courseRuns.upcoming}
         />
         <CourseSection
-          title="Completed courses"
+          title={COURSE_SECTION_TITLES.completed}
           subtitle={SAVED_FOR_LATER_COURSES_SECTION_SUBTITLE}
           component={CompletedCourseCard}
           courseRuns={courseRuns.completed}
         />
         <CourseSection
-          title="Courses saved for later"
+          title={COURSE_SECTION_TITLES.savedForLater}
           subtitle={SAVED_FOR_LATER_COURSES_SECTION_SUBTITLE}
           component={SavedForLaterCourseCard}
           courseRuns={courseRuns.savedForLater}

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
@@ -8,8 +8,8 @@ import MarkCompleteModalContext from './MarkCompleteModalContext';
 import ModalBody from './ModalBody';
 import { updateCourseCompleteStatusRequest } from './data/service';
 
-export const MARK_ARCHIVED_DEFAULT_LABEL = 'Save course for later';
-export const MARK_ARCHIVED_PENDING_LABEL = 'Saving course for later...';
+export const MARK_SAVED_FOR_LATER_DEFAULT_LABEL = 'Save course for later';
+export const MARK_SAVED_FOR_LATER_PENDING_LABEL = 'Saving course for later...';
 
 const initialState = {
   confirmButtonState: 'default',
@@ -79,8 +79,8 @@ const MarkCompleteModal = ({
         buttons={[
           <StatefulButton
             labels={{
-              default: MARK_ARCHIVED_DEFAULT_LABEL,
-              pending: MARK_ARCHIVED_PENDING_LABEL,
+              default: MARK_SAVED_FOR_LATER_DEFAULT_LABEL,
+              pending: MARK_SAVED_FOR_LATER_PENDING_LABEL,
             }}
             disabledStates={['pending']}
             className="confirm-mark-complete-btn btn-primary btn-brand-primary"

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/tests/MarkCompleteModal.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/tests/MarkCompleteModal.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { AppContext } from '@edx/frontend-platform/react';
 
-import MarkCompleteModal, { MARK_ARCHIVED_DEFAULT_LABEL, MARK_ARCHIVED_PENDING_LABEL } from '../MarkCompleteModal';
+import MarkCompleteModal, { MARK_SAVED_FOR_LATER_DEFAULT_LABEL, MARK_SAVED_FOR_LATER_PENDING_LABEL } from '../MarkCompleteModal';
 import * as service from '../data/service';
 
 jest.mock('../data/service');
@@ -38,11 +38,11 @@ describe('<MarkCompleteModal />', () => {
     ));
     wrapper.find('.confirm-mark-complete-btn').hostNodes().simulate('click');
     expect(service.updateCourseCompleteStatusRequest).toBeCalledWith({
-      course_id: 'course-v1:my-test-course',
-      enterprise_id: 'example-enterprise-uuid',
+      course_id: initialProps.courseId,
+      enterprise_id: enterpriseConfig.uuid,
       saved_for_later: true,
     });
-    expect(wrapper.find('.confirm-mark-complete-btn').hostNodes().text()).toEqual(MARK_ARCHIVED_PENDING_LABEL);
+    expect(wrapper.find('.confirm-mark-complete-btn').hostNodes().text()).toEqual(MARK_SAVED_FOR_LATER_PENDING_LABEL);
   });
 
   it('handles confirm click with error', async () => {
@@ -59,11 +59,11 @@ describe('<MarkCompleteModal />', () => {
       wrapper.find('.confirm-mark-complete-btn').hostNodes().simulate('click');
     });
     expect(service.updateCourseCompleteStatusRequest).toBeCalledWith({
-      course_id: 'course-v1:my-test-course',
-      enterprise_id: 'example-enterprise-uuid',
+      course_id: initialProps.courseId,
+      enterprise_id: enterpriseConfig.uuid,
       saved_for_later: true,
     });
-    expect(wrapper.find('.confirm-mark-complete-btn').hostNodes().text()).toEqual(MARK_ARCHIVED_DEFAULT_LABEL);
+    expect(wrapper.find('.confirm-mark-complete-btn').hostNodes().text()).toEqual(MARK_SAVED_FOR_LATER_DEFAULT_LABEL);
   });
 
   it('handles close modal', () => {

--- a/src/components/dashboard/main-content/course-enrollments/data/constants.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/constants.js
@@ -5,3 +5,9 @@ export const CLEAR_COURSE_ENROLLMENTS = 'CLEAR_COURSE_ENROLLMENTS';
 export const UPDATE_COURSE_RUN_STATUS = 'UPDATE_COURSE_RUN_STATUS';
 export const UPDATE_IS_MARK_COURSE_COMPLETE_SUCCESS = 'UPDATE_IS_MARK_COURSE_COMPLETE_SUCCESS';
 export const UPDATE_IS_UNARCHIVE_COURSE_SUCCESS = 'UPDATE_IS_UNARCHIVE_COURSE_SUCCESS';
+export const COURSE_STATUSES = {
+  inProgress: 'in_progress',
+  upcoming: 'upcoming',
+  completed: 'completed',
+  savedForLater: 'savedForLater',
+};

--- a/src/components/dashboard/main-content/course-enrollments/data/selectors.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { COURSE_STATUSES } from './constants';
 
 export const getIsLoading = state => state.courseEnrollments.isLoading;
 export const getCourseRuns = state => state.courseEnrollments.courseRuns;
@@ -35,19 +36,20 @@ const transformCourseRun = (originalCourseRun) => {
 
 export const filterCourseRuns = (courseRuns) => {
   const courseRunsByStatus = {
-    in_progress: [],
-    upcoming: [],
-    completed: [],
-    savedForLater: [],
+    [COURSE_STATUSES.inProgress]: [],
+    [COURSE_STATUSES.upcoming]: [],
+    [COURSE_STATUSES.completed]: [],
+    [COURSE_STATUSES.savedForLater]: [],
   };
   if (courseRuns && courseRuns.length > 0) {
     const transformedCourseRuns = courseRuns.map(transformCourseRun);
     Object.keys(courseRunsByStatus).forEach((status) => {
       courseRunsByStatus[status] = transformedCourseRuns.filter((courseRun) => {
-        if (courseRun.courseRunStatus !== 'completed' || (courseRun.courseRunStatus === 'completed' && !courseRun.savedForLater)) {
+        if (courseRun.courseRunStatus !== COURSE_STATUSES.completed
+          || (courseRun.courseRunStatus === COURSE_STATUSES.completed && !courseRun.savedForLater)) {
           return courseRun.courseRunStatus === status;
         }
-        if (status === 'savedForLater' && courseRun.savedForLater) {
+        if (status === COURSE_STATUSES.savedForLater && courseRun.savedForLater) {
           return true;
         }
         return false;

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/selectors.test.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/selectors.test.js
@@ -1,29 +1,34 @@
 import {
   filterCourseRuns,
 } from '../selectors';
+import { COURSE_STATUSES } from '../constants';
 import { createRawCourseRun } from '../../tests/enrollment-testutils';
 
 describe('filterCourseRunsByStatus', () => {
   it('categorizes in_progress and upcoming courses correctly', () => {
     const inProgressCourse = createRawCourseRun();
-    const upcomingCourse = { ...createRawCourseRun(), courseRunStatus: 'upcoming' };
+    const upcomingCourse = { ...createRawCourseRun(), courseRunStatus: COURSE_STATUSES.upcoming };
     const result = filterCourseRuns([inProgressCourse, upcomingCourse]);
-    expect(result.in_progress[0].courseRunStatus).toEqual('in_progress');
+    expect(result.in_progress[0].courseRunStatus).toEqual(COURSE_STATUSES.inProgress);
     expect(result.in_progress.length).toEqual(1);
     expect(result.upcoming.length).toEqual(1);
-    expect(result.upcoming[0].courseRunStatus).toEqual('upcoming');
+    expect(result.upcoming[0].courseRunStatus).toEqual(COURSE_STATUSES.upcoming);
     expect(result.completed.length).toEqual(0);
     expect(result.savedForLater.length).toEqual(0);
   });
   it('categorizes completed and saved for later courses correctly', () => {
-    const completedCourse = { ...createRawCourseRun(), courseRunStatus: 'completed' };
-    const savedForLaterCourse = { ...createRawCourseRun(), courseRunStatus: 'completed', savedForLater: true };
+    const completedCourse = { ...createRawCourseRun(), courseRunStatus: COURSE_STATUSES.completed };
+    const savedForLaterCourse = {
+      ...createRawCourseRun(),
+      courseRunStatus: COURSE_STATUSES.completed,
+      savedForLater: true,
+    };
     const result = filterCourseRuns([completedCourse, savedForLaterCourse]);
-    expect(result.completed[0].courseRunStatus).toEqual('completed');
+    expect(result.completed[0].courseRunStatus).toEqual(COURSE_STATUSES.completed);
     expect(result.completed[0].savedForLater).toEqual(false);
     expect(result.completed.length).toEqual(1);
     expect(result.savedForLater.length).toEqual(1);
-    expect(result.savedForLater[0].courseRunStatus).toEqual('completed');
+    expect(result.savedForLater[0].courseRunStatus).toEqual(COURSE_STATUSES.completed);
     expect(result.savedForLater[0].savedForLater).toEqual(true);
     expect(result.in_progress.length).toEqual(0);
     expect(result.upcoming.length).toEqual(0);

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -17,9 +17,11 @@ import {
 } from './enrollment-testutils';
 
 // component to test
-import { CourseEnrollments } from '../CourseEnrollments';
-
+import { CourseEnrollments, COURSE_SECTION_TITLES } from '../CourseEnrollments';
+import { MARK_MOVE_TO_IN_PROGRESS_DEFAULT_LABEL } from '../course-cards/move-to-in-progress-modal/MoveToInProgressModal';
+import { MARK_SAVED_FOR_LATER_DEFAULT_LABEL } from '../course-cards/mark-complete-modal/MarkCompleteModal';
 import { updateCourseCompleteStatusRequest } from '../course-cards/mark-complete-modal/data/service';
+import { COURSE_STATUSES } from '../data/constants';
 
 // TODO: Need to confirm if this is the best way to mock auth.
 jest.mock('@edx/frontend-platform/auth');
@@ -34,7 +36,7 @@ const enterpriseConfig = {
   uuid: 'test-enterprise-uuid',
 };
 const completedCourseRun = createCompletedCourseRun();
-const inProgCourseRun = { ...completedCourseRun, courseRunStatus: 'in_progress' };
+const inProgCourseRun = { ...completedCourseRun, courseRunStatus: COURSE_STATUSES.inProgress };
 const savedForLaterCourseRun = { ...completedCourseRun, savedForLater: true };
 
 const defaultInitialProps = defaultInitialEnrollmentProps({ genericMockFn });
@@ -67,16 +69,16 @@ describe('Course enrollements', () => {
   });
   test('loads enrollments component', () => {
     renderEnrollmentsComponent(initProps);
-    expect(screen.getByText('My courses in progress')).toBeInTheDocument();
-    expect(screen.getByText('Completed courses')).toBeInTheDocument();
-    expect(screen.getByText('Courses saved for later')).toBeInTheDocument();
-    expect(screen.getAllByText('edX Demonstration Course').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(COURSE_SECTION_TITLES.inProgress)).toBeInTheDocument();
+    expect(screen.getByText(COURSE_SECTION_TITLES.completed)).toBeInTheDocument();
+    expect(screen.getByText(COURSE_SECTION_TITLES.savedForLater)).toBeInTheDocument();
+    expect(screen.getAllByText(inProgCourseRun.title).length).toBeGreaterThanOrEqual(1);
   });
 
   it('generates course status update on move to in progress action', () => {
     renderEnrollmentsComponent({ ...initProps });
-    expect(screen.getByRole('button', { name: 'Move course to In Progress' })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Move course to In Progress' }));
+    expect(screen.getByRole('button', { name: MARK_MOVE_TO_IN_PROGRESS_DEFAULT_LABEL })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: MARK_MOVE_TO_IN_PROGRESS_DEFAULT_LABEL }));
 
     // TODO This test only validates 'half way', we ideally want to update it to
     // validate the UI results. Skipping at the time of writing since need to
@@ -87,7 +89,7 @@ describe('Course enrollements', () => {
 
   it('generates course status update on move to saved for later action', () => {
     renderEnrollmentsComponent({ ...initProps });
-    const saveForLaterButton = screen.getByRole('button', { name: 'Save course for later' });
+    const saveForLaterButton = screen.getByRole('button', { name: MARK_SAVED_FOR_LATER_DEFAULT_LABEL });
     expect(saveForLaterButton).toBeInTheDocument();
     fireEvent.click(saveForLaterButton);
 

--- a/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
+++ b/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
@@ -1,4 +1,5 @@
 import thunk from 'redux-thunk';
+import { COURSE_STATUSES } from '../data/constants';
 
 /**
  * Creates a redux-thunk based store with default emailSettings for the app.
@@ -27,7 +28,7 @@ const createMockStore = (configureMockStore) => {
 const createCompletedCourseRun = () => {
   const completedCourseRun = {
     courseRunId: 'course-v1:edX+DemoX+Demo_Course',
-    courseRunStatus: 'completed',
+    courseRunStatus: COURSE_STATUSES.completed,
     linkToCourse: 'https://edx.org/',
     title: 'edX Demonstration Course',
     notifications: [],
@@ -47,7 +48,7 @@ const createRawCourseRun = () => ({
   emailsEnabled: true,
   dueDates: [],
   completed: false,
-  courseRunStatus: 'in_progress',
+  courseRunStatus: COURSE_STATUSES.inProgress,
   savedForLater: false,
 });
 


### PR DESCRIPTION
Ensures that we're consistent in what we call things, makes tests less brittle when names change.