### PR TITLE
Exempt certain files from prefer-deafault-export eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,14 @@
     ],
     "template-curly-spacing": "off"
   },
+  "overrides": [
+    {
+      "files": ["**/index.js", "**/service.js", "**/hooks.js", "**/hooks.jsx"],
+      "rules": {
+        "import/prefer-default-export": "off"
+      }
+    }
+  ],
   "env": {
     "jest": true
   },

--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as App } from './App';

--- a/src/components/course/index.js
+++ b/src/components/course/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as CoursePage } from './CoursePage';

--- a/src/components/dashboard/data/service.js
+++ b/src/components/dashboard/data/service.js
@@ -5,5 +5,4 @@ const fetchEntepriseCustomerConfig = (slug) => {
   return getAuthenticatedHttpClient().get(url);
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { fetchEntepriseCustomerConfig };

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as DashboardPage } from './DashboardPage';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/data/index.js
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/data/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { updateEmailSettings } from './actions';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/data/service.js
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/data/service.js
@@ -21,5 +21,4 @@ const updateEmailSettings = (courseRunId, hasEmailsEnabled) => {
   );
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { updateEmailSettings };

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/index.js
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/index.js
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as EmailSettingsModal } from './EmailSettingsModal';
 export { default as reducer } from './data/reducer';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/data/service.js
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/data/service.js
@@ -15,7 +15,6 @@ export const ENROLL_ENDPOINT = '/enterprise_learner_portal/api/v1/enterprise_cou
  * @param {RequestOptions} options
  * @requires {Promise} Request promise.
  */
-// eslint-disable-next-line import/prefer-default-export
 export const updateCourseCompleteStatusRequest = (options) => {
   let url = `${process.env.LMS_BASE_URL}${ENROLL_ENDPOINT}`;
   if (options) {

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/index.js
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as MarkCompleteModal } from './MarkCompleteModal';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/index.js
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as MoveToInProgressModal } from './MoveToInProgressModal';

--- a/src/components/dashboard/main-content/course-enrollments/index.js
+++ b/src/components/dashboard/main-content/course-enrollments/index.js
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as CourseEnrollments } from './CourseEnrollments';
 export { reducer } from './data';

--- a/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
+++ b/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
@@ -75,7 +75,6 @@ const defaultInitialEnrollmentProps = ({ genericMockFn = () => {} }) => ({
 });
 
 export {
-  // eslint-disable-next-line import/prefer-default-export
   createMockStore,
   createCompletedCourseRun,
   defaultInitialEnrollmentProps,

--- a/src/components/dashboard/main-content/index.js
+++ b/src/components/dashboard/main-content/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as DashboardMainContent } from './DashboardMainContent';

--- a/src/components/dashboard/sidebar/index.js
+++ b/src/components/dashboard/sidebar/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as DashboardSidebar } from './DashboardSidebar';

--- a/src/components/dashboard/sidebar/offers/data/service.js
+++ b/src/components/dashboard/sidebar/offers/data/service.js
@@ -5,5 +5,4 @@ const fetchOffers = () => {
   return getAuthenticatedHttpClient().get(offersUrl);
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export { fetchOffers };

--- a/src/components/enterprise-banner/index.js
+++ b/src/components/enterprise-banner/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as EnterpriseBanner } from './EnterpriseBanner';

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -22,7 +22,6 @@ const defaultBrandingConfig = {
  * @param {string} [enterpriseSlug] enterprise slug.
  * @returns {object} EnterpriseConfig
  */
-// eslint-disable-next-line import/prefer-default-export
 export function useEnterpriseCustomerConfig(enterpriseSlug) {
   const [enterpriseConfig, setEnterpriseConfig] = useState();
 

--- a/src/components/enterprise-page/index.js
+++ b/src/components/enterprise-page/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as EnterprisePage } from './EnterprisePage';

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -6,7 +6,6 @@ import { isNull } from '../../../utils/common';
 import { LICENSE_STATUS } from './constants';
 import { fetchSubscriptionLicensesForUser } from './service';
 
-// eslint-disable-next-line import/prefer-default-export
 export function useSubscriptionLicenseForUser(subscriptionPlan) {
   const [license, setLicense] = useState();
   const [isLoading, setIsLoading] = useState(true);

--- a/src/components/enterprise-user-subsidy/data/service.js
+++ b/src/components/enterprise-user-subsidy/data/service.js
@@ -1,7 +1,6 @@
 import { getAuthenticatedUser, getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import qs from 'query-string';
 
-// eslint-disable-next-line import/prefer-default-export
 export function fetchSubscriptionLicensesForUser(subscriptionUuid) {
   const user = getAuthenticatedUser();
   const { email } = user;

--- a/src/components/enterprise-user-subsidy/index.js
+++ b/src/components/enterprise-user-subsidy/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as UserSubsidy, UserSubsidyContext } from './UserSubsidy';

--- a/src/components/layout/data/hooks.js
+++ b/src/components/layout/data/hooks.js
@@ -6,7 +6,6 @@ import { isDefinedAndNotNull, isDefined } from '../../../utils/common';
 const COLOR_LIGHTEN_DARKEN_MODIFIER = 0.2;
 const COLOR_MIX_MODIFIER = 0.1;
 
-// eslint-disable-next-line import/prefer-default-export
 export const useStylesForCustomBrandColors = (enterpriseConfig) => {
   const brandColors = useMemo(
     () => {

--- a/src/components/license-activation/data/hooks.js
+++ b/src/components/license-activation/data/hooks.js
@@ -3,7 +3,6 @@ import { logError } from '@edx/frontend-platform/logging';
 
 import { activateLicense } from './service';
 
-// eslint-disable-next-line import/prefer-default-export
 export function useLicenseActivation(activationKey) {
   const [activationSuccess, setActivationSuccess] = useState(false);
   const [activationError, setActivationError] = useState(false);

--- a/src/components/license-activation/data/service.js
+++ b/src/components/license-activation/data/service.js
@@ -1,7 +1,6 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import qs from 'query-string';
 
-// eslint-disable-next-line import/prefer-default-export
 export function activateLicense(activationKey) {
   const queryParams = { activation_key: activationKey };
   const url = `${process.env.LICENSE_MANAGER_URL}/api/v1/license-activation/?${qs.stringify(queryParams)}`;

--- a/src/components/license-activation/index.js
+++ b/src/components/license-activation/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as LicenseActivationPage } from './LicenseActivationPage';

--- a/src/components/loading-spinner/index.js
+++ b/src/components/loading-spinner/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as LoadingSpinner } from './LoadingSpinner';

--- a/src/components/login-redirect/index.js
+++ b/src/components/login-redirect/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as LoginRedirect } from './LoginRedirect';

--- a/src/components/preview-expand/index.js
+++ b/src/components/preview-expand/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as PreviewExpand } from './PreviewExpand';

--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as SearchPage } from './SearchPage';

--- a/src/components/search/popular-courses/index.js
+++ b/src/components/search/popular-courses/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as PopularCourses } from './PopularCoursesIndex';

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState, useEffect } from 'react';
 
-// eslint-disable-next-line import/prefer-default-export
 export const useWindowSize = () => {
   const isClient = typeof window === 'object';
 


### PR DESCRIPTION
index.js, service.js and hooks.js(x) files are now exempt from the rule.
We generally don't have a default export from these files, and were having to manually disable eslint each time.

@binodpant I didn't want to turn this rule off globally, because I still think it's valuable for React components. So I looked at the type of file we were using it in and turned it off for just those files. LMK if you have strong opinions either way.