### PR TITLE
add pacing type, discounted price in sidebar, date validation for subscription plan

### DIFF
--- a/src/components/course/CourseSidebar.jsx
+++ b/src/components/course/CourseSidebar.jsx
@@ -7,12 +7,14 @@ import {
   faGraduationCap,
   faCertificate,
   faFileVideo,
+  faUser,
 } from '@fortawesome/free-solid-svg-icons';
 import ISO6391 from 'iso-639-1';
 
 import { CourseContext } from './CourseContextProvider';
 import CourseSidebarListItem from './CourseSidebarListItem';
 import CourseAssociatedPrograms from './CourseAssociatedPrograms';
+import CourseSidebarPrice from './CourseSidebarPrice';
 
 import { isDefinedAndNotNull, hasTruthyValue } from '../../utils/common';
 import {
@@ -20,6 +22,7 @@ import {
   useCoursePartners,
   useCourseRunWeeksToComplete,
   useCourseTranscriptLanguages,
+  useCoursePacingType,
 } from './data/hooks';
 
 import './styles/CourseSidebar.scss';
@@ -31,6 +34,7 @@ export default function CourseSidebar() {
   const [partners, institutionLabel] = useCoursePartners(course);
   const [weeksToComplete, weeksLabel] = useCourseRunWeeksToComplete(activeCourseRun);
   const [transcriptLanguages, transcriptLabel] = useCourseTranscriptLanguages(activeCourseRun);
+  const [pacingType, pacingTypeContent] = useCoursePacingType(activeCourseRun);
 
   return (
     <>
@@ -56,7 +60,7 @@ export default function CourseSidebar() {
         <CourseSidebarListItem
           icon={faTag}
           label="Price"
-          content="Free"
+          content={<CourseSidebarPrice />}
         />
         {partners && partners.length > 0 && (
           <CourseSidebarListItem
@@ -103,6 +107,13 @@ export default function CourseSidebar() {
             content={transcriptLanguages.map(language => (
               ISO6391.getNativeName(language.slice(0, 2))
             )).join(', ')}
+          />
+        )}
+        {pacingType && (
+          <CourseSidebarListItem
+            icon={faUser}
+            label="Course Type"
+            content={pacingTypeContent}
           />
         )}
       </ul>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -24,9 +24,11 @@ const CourseSidebarPrice = () => {
   if (userSubsidy?.subsidyType === LICENSE_SUBSIDY_TYPE) {
     return (
       <>
-        <div className="mb-2">
-          <del>${coursePrice.list} USD</del>
-        </div>
+        {!enterpriseConfig.hideCourseOriginalPrice && (
+          <div className="mb-2">
+            <del>${coursePrice.list} USD</del>
+          </div>
+        )}
         <span>Included in your subscription</span>
       </>
     );
@@ -39,11 +41,19 @@ const CourseSidebarPrice = () => {
         <div className="mb-2">
           {coursePrice.discounted > 0 ? (
             <>
-              ${coursePrice.discounted} <del>${coursePrice.list}</del> USD
+              ${coursePrice.discounted}
+              {!enterpriseConfig?.hideCourseOriginalPrice && (
+                <>
+                  {' '}
+                  <del>${coursePrice.list}</del>
+                </>
+              )}
+              {' '}
+              USD
             </>
           ) : (
             <>
-              <del>${coursePrice.list} USD</del>
+              ${coursePrice.discounted} USD
             </>
           )}
         </div>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -1,0 +1,52 @@
+import React, { useContext } from 'react';
+import Skeleton from 'react-loading-skeleton';
+import { AppContext } from '@edx/frontend-platform/react';
+
+import { CourseContext } from './CourseContextProvider';
+
+import { LICENSE_SUBSIDY_TYPE } from './data/constants';
+import {
+  useCoursePriceForUserSubsidy,
+  useFetchUserSubsidyForCourse,
+} from './data/hooks';
+
+const CourseSidebarPrice = () => {
+  const { state } = useContext(CourseContext);
+  const { activeCourseRun } = state;
+  const { enterpriseConfig } = useContext(AppContext);
+  const [userSubsidy, isLoading] = useFetchUserSubsidyForCourse(activeCourseRun, enterpriseConfig);
+  const coursePrice = useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy);
+
+  if (isLoading || !coursePrice) {
+    return <Skeleton height={24} />;
+  }
+
+  if (userSubsidy?.subsidyType === LICENSE_SUBSIDY_TYPE) {
+    return (
+      <>
+        <div className="mb-2">
+          <del>${coursePrice.list} USD</del>
+        </div>
+        <span>Included in your subscription</span>
+      </>
+    );
+  }
+
+  const hasDiscountedPrice = coursePrice?.discounted < coursePrice?.list;
+  if (hasDiscountedPrice) {
+    return (
+      <>
+        <div className="mb-2">
+          ${coursePrice.discounted} <del>${coursePrice.list}</del> USD
+        </div>
+        <span>Sponsored by {enterpriseConfig.name}</span>
+      </>
+    );
+  }
+
+  return (
+    <span>${coursePrice.list} USD</span>
+  );
+};
+
+export default CourseSidebarPrice;

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -15,7 +15,7 @@ const CourseSidebarPrice = () => {
   const { activeCourseRun } = state;
   const { enterpriseConfig } = useContext(AppContext);
   const [userSubsidy, isLoading] = useFetchUserSubsidyForCourse(activeCourseRun, enterpriseConfig);
-  const coursePrice = useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy);
+  const [coursePrice, currency] = useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy);
 
   if (isLoading || !coursePrice) {
     return <Skeleton height={24} />;
@@ -26,7 +26,7 @@ const CourseSidebarPrice = () => {
       <>
         {!enterpriseConfig.hideCourseOriginalPrice && (
           <div className="mb-2">
-            <del>${coursePrice.list} USD</del>
+            <del>${coursePrice.list} {currency}</del>
           </div>
         )}
         <span>Included in your subscription</span>
@@ -49,11 +49,10 @@ const CourseSidebarPrice = () => {
                 </>
               )}
               {' '}
-              USD
             </>
           ) : (
             <>
-              ${coursePrice.discounted} USD
+              ${coursePrice.discounted} {currency}
             </>
           )}
         </div>
@@ -63,7 +62,7 @@ const CourseSidebarPrice = () => {
   }
 
   return (
-    <span>${coursePrice.list} USD</span>
+    <span>${coursePrice.list} {currency}</span>
   );
 };
 

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -32,12 +32,20 @@ const CourseSidebarPrice = () => {
     );
   }
 
-  const hasDiscountedPrice = coursePrice?.discounted < coursePrice?.list;
+  const hasDiscountedPrice = coursePrice.discounted < coursePrice.list;
   if (hasDiscountedPrice) {
     return (
       <>
         <div className="mb-2">
-          ${coursePrice.discounted} <del>${coursePrice.list}</del> USD
+          {coursePrice.discounted > 0 ? (
+            <>
+              ${coursePrice.discounted} <del>${coursePrice.list}</del> USD
+            </>
+          ) : (
+            <>
+              <del>${coursePrice.list} USD</del>
+            </>
+          )}
         </div>
         <span>Sponsored by {enterpriseConfig.name}</span>
       </>

--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -13,3 +13,5 @@ export const SUBSIDY_DISCOUNT_TYPE_ABSOLUTE = 'absolute';
 export const LICENSE_SUBSIDY_TYPE = 'license';
 
 export const PROMISE_FULFILLED = 'fulfilled';
+
+export const CURRENCY_USD = 'USD';

--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -3,3 +3,11 @@ export const SET_COURSE_RUN = 'SET_COURSE_RUN';
 export const SET_ENROLLMENTS = 'SET_ENROLLMENTS';
 export const SET_ENTITLEMENTS = 'SET_ENTITLEMENTS';
 export const SET_IS_COURSE_IN_CATALOG = 'SET_IS_COURSE_IN_CATALOG';
+
+export const INSTRUCTOR_PACED_TYPE = 'instructor';
+export const SELF_PACED_TYPE = 'self';
+
+export const SUBSIDY_DISCOUNT_TYPE_PERCENTAGE = 'percentage';
+export const SUBSIDY_DISCOUNT_TYPE_ABSOLUTE = 'absolute';
+
+export const LICENSE_SUBSIDY_TYPE = 'license';

--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -11,3 +11,5 @@ export const SUBSIDY_DISCOUNT_TYPE_PERCENTAGE = 'percentage';
 export const SUBSIDY_DISCOUNT_TYPE_ABSOLUTE = 'absolute';
 
 export const LICENSE_SUBSIDY_TYPE = 'license';
+
+export const PROMISE_FULFILLED = 'fulfilled';

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -10,6 +10,7 @@ import {
   SELF_PACED_TYPE,
   SUBSIDY_DISCOUNT_TYPE_ABSOLUTE,
   SUBSIDY_DISCOUNT_TYPE_PERCENTAGE,
+  CURRENCY_USD,
 } from './constants';
 
 export function useAllCourseData({ courseKey, enterpriseConfig }) {
@@ -177,6 +178,8 @@ export function useFetchUserSubsidyForCourse(activeCourseRun, enterpriseConfig) 
 }
 
 export function useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy) {
+  const currency = CURRENCY_USD;
+
   const coursePrice = useMemo(
     () => {
       const listPrice = activeCourseRun.firstEnrollablePaidSeatPrice;
@@ -214,5 +217,5 @@ export function useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy) {
     [activeCourseRun, userSubsidy],
   );
 
-  return coursePrice;
+  return [coursePrice, currency];
 }

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -160,8 +160,8 @@ export function useFetchUserSubsidyForCourse(activeCourseRun, enterpriseConfig) 
           activeCourseRun,
         });
         try {
-          const data = await courseService.fetchAllEnterpriseUserSubsidies();
-          setUserSubsidy(data);
+          const subsidy = await courseService.fetchEnterpriseUserSubsidy();
+          setUserSubsidy(subsidy);
         } catch (error) {
           logError(error);
         } finally {

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
+import { isDefinedAndNotNull } from '../../../utils/common';
 import CourseService from './service';
 import { isCourseInstructorPaced, isCourseSelfPaced, numberWithPrecision } from './utils';
 import {
@@ -180,13 +181,17 @@ export function useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy) {
     () => {
       const listPrice = activeCourseRun.firstEnrollablePaidSeatPrice;
 
-      if (!listPrice || !userSubsidy) {
+      if (!listPrice) {
         return null;
       }
 
       const priceDetails = {
         list: numberWithPrecision(listPrice),
       };
+      if (!userSubsidy) {
+        return priceDetails;
+      }
+
       const { discountType, discountValue } = userSubsidy;
       let discountedPrice;
 
@@ -198,7 +203,12 @@ export function useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy) {
         discountedPrice = Math.max(listPrice - discountValue, 0);
       }
 
-      priceDetails.discounted = discountedPrice ? numberWithPrecision(discountedPrice) : priceDetails.list;
+      if (isDefinedAndNotNull(discountedPrice)) {
+        priceDetails.discounted = numberWithPrecision(discountedPrice);
+      } else {
+        priceDetails.discounted = priceDetails.list;
+      }
+
       return priceDetails;
     },
     [activeCourseRun, userSubsidy],

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -50,6 +50,10 @@ export function isCourseSelfPaced(pacingType) {
   return pacingType === 'self_paced';
 }
 
+export function isCourseInstructorPaced(pacingType) {
+  return pacingType === 'instructor_paced';
+}
+
 export function programIsMicroMasters(type) {
   return type.toLowerCase() === 'micromasters';
 }
@@ -106,3 +110,5 @@ export function getProgramIcon(type) {
       return VerifiedSvgIcon;
   }
 }
+
+export const numberWithPrecision = (number, precision = 2) => number.toFixed(precision);

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -30,7 +30,7 @@ export function useEnterpriseCustomerConfig(enterpriseSlug) {
       .then((response) => {
         const { results } = camelCaseObject(response.data);
         const config = results.pop();
-        if (config && config.enableLearnerPortal) {
+        if (config?.enableLearnerPortal) {
           const brandingConfiguration = config.brandingConfiguration || defaultBrandingConfig;
           // TODO: bannerBackgroundColor and bannerBorderColor will be replaced by
           // secondaryColor and tertiaryColor, respectively.
@@ -44,12 +44,14 @@ export function useEnterpriseCustomerConfig(enterpriseSlug) {
             uuid,
             slug,
             contactEmail,
+            hideCourseOriginalPrice,
           } = config;
           setEnterpriseConfig({
             name,
             uuid,
             slug,
             contactEmail,
+            hideCourseOriginalPrice,
             branding: {
               logo,
               colors: {

--- a/src/components/enterprise-user-subsidy/SubscriptionSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/SubscriptionSubsidy.jsx
@@ -4,16 +4,44 @@ import { Redirect, useRouteMatch } from 'react-router-dom';
 import { StatusAlert } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
+import { useRenderContactHelpText } from '../../utils/hooks';
+import { isNull, hasValidStartExpirationDates } from '../../utils/common';
 import { LICENSE_STATUS } from './data/constants';
 
-import { useRenderContactHelpText } from '../../utils/hooks';
-
-const SubscriptionSubsidy = ({ subscriptionLicense }) => {
+const SubscriptionSubsidy = ({ plan, license }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const match = useRouteMatch(`/${enterpriseConfig.slug}`);
   const renderContactHelpText = useRenderContactHelpText(enterpriseConfig);
 
-  if (subscriptionLicense === null) {
+  if (!plan) {
+    return null;
+  }
+
+  if (!hasValidStartExpirationDates(plan)) {
+    if (!match.isExact) {
+      return <Redirect to={`/${enterpriseConfig.slug}`} />;
+    }
+    return (
+      <>
+        <div className="container-fluid mt-3">
+          <StatusAlert
+            alertType="danger"
+            className="mb-0"
+            dialog={(
+              <>
+                Your organization does not have an active subscription plan.
+                Please {renderContactHelpText()} for further information.
+              </>
+            )}
+            dismissible={false}
+            open
+          />
+        </div>
+      </>
+    );
+  }
+
+  if (isNull(license)) {
     if (!match.isExact) {
       return <Redirect to={`/${enterpriseConfig.slug}`} />;
     }
@@ -37,13 +65,13 @@ const SubscriptionSubsidy = ({ subscriptionLicense }) => {
     );
   }
 
-  if (subscriptionLicense && subscriptionLicense.status !== LICENSE_STATUS.ACTIVATED) {
+  if (license?.status !== LICENSE_STATUS.ACTIVATED) {
     if (!match.isExact) {
       return <Redirect to={`/${enterpriseConfig.slug}`} />;
     }
     return (
       <>
-        {subscriptionLicense.status === LICENSE_STATUS.ASSIGNED && (
+        {license.status === LICENSE_STATUS.ASSIGNED && (
           <div className="container-fluid mt-3">
             <StatusAlert
               alertType="warning"
@@ -59,7 +87,7 @@ const SubscriptionSubsidy = ({ subscriptionLicense }) => {
             />
           </div>
         )}
-        {subscriptionLicense.status === LICENSE_STATUS.DEACTIVATED && (
+        {license.status === LICENSE_STATUS.DEACTIVATED && (
           <div className="container-fluid mt-3">
             <StatusAlert
               alertType="danger"
@@ -84,11 +112,18 @@ const SubscriptionSubsidy = ({ subscriptionLicense }) => {
 };
 
 SubscriptionSubsidy.propTypes = {
-  subscriptionLicense: PropTypes.shape(),
+  license: PropTypes.shape({
+    status: PropTypes.string,
+  }),
+  plan: PropTypes.shape({
+    startDate: PropTypes.string,
+    expirationDate: PropTypes.string,
+  }),
 };
 
 SubscriptionSubsidy.defaultProps = {
-  subscriptionLicense: undefined,
+  license: undefined,
+  plan: undefined,
 };
 
 export default SubscriptionSubsidy;

--- a/src/components/enterprise-user-subsidy/SubscriptionSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/SubscriptionSubsidy.jsx
@@ -4,8 +4,12 @@ import { Redirect, useRouteMatch } from 'react-router-dom';
 import { StatusAlert } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
+import {
+  isDefinedAndNotNull,
+  isNull,
+  hasValidStartExpirationDates,
+} from '../../utils/common';
 import { useRenderContactHelpText } from '../../utils/hooks';
-import { isNull, hasValidStartExpirationDates } from '../../utils/common';
 import { LICENSE_STATUS } from './data/constants';
 
 const SubscriptionSubsidy = ({ plan, license }) => {
@@ -65,7 +69,7 @@ const SubscriptionSubsidy = ({ plan, license }) => {
     );
   }
 
-  if (license?.status !== LICENSE_STATUS.ACTIVATED) {
+  if (isDefinedAndNotNull(license) && license.status !== LICENSE_STATUS.ACTIVATED) {
     if (!match.isExact) {
       return <Redirect to={`/${enterpriseConfig.slug}`} />;
     }

--- a/src/components/enterprise-user-subsidy/UserSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidy.jsx
@@ -5,6 +5,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { LoadingSpinner } from '../loading-spinner';
 import SubscriptionSubsidy from './SubscriptionSubsidy';
 
+import { isNull, hasValidStartExpirationDates } from '../../utils/common';
 import { useSubscriptionLicenseForUser } from './data/hooks';
 import { LICENSE_STATUS, LOADING_SCREEN_READER_TEXT } from './data/constants';
 
@@ -28,9 +29,12 @@ const UserSubsidy = ({ children }) => {
 
       // determine whether user has access to the Learner Portal if their organization
       // has an active Subscription Plan.
-      if (subscriptionPlan && subscriptionLicense === null) {
+      if (!subscriptionPlan || !hasValidStartExpirationDates(subscriptionPlan)) {
         hasAccessToPortal = false;
-      } else if (subscriptionLicense && subscriptionLicense.status !== LICENSE_STATUS.ACTIVATED) {
+      }
+
+      // determine whether user has access to the Learner Portal if they have an activated license
+      if (isNull(subscriptionLicense) || subscriptionLicense?.status !== LICENSE_STATUS.ACTIVATED) {
         hasAccessToPortal = false;
       }
 
@@ -52,9 +56,11 @@ const UserSubsidy = ({ children }) => {
       {/**
        * SubscriptionSubsidy takes care of redirecting the user to `/${enterpriseConfig.slug}`
        * if their organization has a subscription plan but they don't have appropriate access
-       * to a license (i.e., status="activated") and rendering warning/error status alerts.
+       * to a license (i.e., status="activated"). it also handles the case where the organization
+       * has an active subscription plan but the current date is not between the plan's start and
+       * expiration dates. The component also handles rendering warning/error status alerts.
        */}
-      <SubscriptionSubsidy subscriptionLicense={subscriptionLicense} />
+      <SubscriptionSubsidy plan={subscriptionPlan} license={subscriptionLicense} />
       {/**
        * Potential direction for code organization for blended use case of subscriptions,
        * codes, and offers:

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -2,46 +2,44 @@ import { useState, useEffect } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
-import { isNull, hasValidStartExpirationDates } from '../../../utils/common';
 import { LICENSE_STATUS } from './constants';
 import { fetchSubscriptionLicensesForUser } from './service';
+import { hasValidStartExpirationDates } from '../../../utils/common';
 
 export function useSubscriptionLicenseForUser(subscriptionPlan) {
   const [license, setLicense] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (!subscriptionPlan || isNull(subscriptionPlan) || !hasValidStartExpirationDates(subscriptionPlan)) {
+    if (!subscriptionPlan || !hasValidStartExpirationDates(subscriptionPlan)) {
       setIsLoading(false);
       return;
     }
 
-    if (subscriptionPlan?.uuid) {
-      fetchSubscriptionLicensesForUser(subscriptionPlan.uuid)
-        .then((response) => {
-          const { results } = camelCaseObject(response.data);
-          const activated = results.filter(result => result.status === LICENSE_STATUS.ACTIVATED);
-          const assigned = results.filter(result => result.status === LICENSE_STATUS.ASSIGNED);
-          const deactivated = results.filter(result => result.status === LICENSE_STATUS.DEACTIVATED);
+    fetchSubscriptionLicensesForUser(subscriptionPlan.uuid)
+      .then((response) => {
+        const { results } = camelCaseObject(response.data);
+        const activated = results.filter(result => result.status === LICENSE_STATUS.ACTIVATED);
+        const assigned = results.filter(result => result.status === LICENSE_STATUS.ASSIGNED);
+        const deactivated = results.filter(result => result.status === LICENSE_STATUS.DEACTIVATED);
 
-          if (activated.length) {
-            setLicense(activated.pop());
-          } else if (assigned.length) {
-            setLicense(assigned.pop());
-          } else if (deactivated.length) {
-            setLicense(deactivated.pop());
-          } else {
-            setLicense(null);
-          }
-        })
-        .catch((error) => {
-          logError(new Error(error));
+        if (activated.length) {
+          setLicense(activated.pop());
+        } else if (assigned.length) {
+          setLicense(assigned.pop());
+        } else if (deactivated.length) {
+          setLicense(deactivated.pop());
+        } else {
           setLicense(null);
-        })
-        .finally(() => {
-          setIsLoading(false);
-        });
-    }
+        }
+      })
+      .catch((error) => {
+        logError(new Error(error));
+        setLicense(null);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
   }, [subscriptionPlan]);
 
   return [license, isLoading];

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
-import { isNull } from '../../../utils/common';
+import { isNull, hasValidStartExpirationDates } from '../../../utils/common';
 import { LICENSE_STATUS } from './constants';
 import { fetchSubscriptionLicensesForUser } from './service';
 
@@ -11,7 +11,12 @@ export function useSubscriptionLicenseForUser(subscriptionPlan) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (subscriptionPlan && subscriptionPlan.uuid) {
+    if (!subscriptionPlan || isNull(subscriptionPlan) || !hasValidStartExpirationDates(subscriptionPlan)) {
+      setIsLoading(false);
+      return;
+    }
+
+    if (subscriptionPlan?.uuid) {
       fetchSubscriptionLicensesForUser(subscriptionPlan.uuid)
         .then((response) => {
           const { results } = camelCaseObject(response.data);
@@ -36,9 +41,6 @@ export function useSubscriptionLicenseForUser(subscriptionPlan) {
         .finally(() => {
           setIsLoading(false);
         });
-    }
-    if (isNull(subscriptionPlan)) {
-      setIsLoading(false);
     }
   }, [subscriptionPlan]);
 

--- a/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
@@ -69,7 +69,7 @@ describe('without subscription plan', () => {
   });
 });
 
-describe('with inactive subscription plan', () => {
+describe('with subscription plan that is expired or has not yet started', () => {
   const contextValue = {
     subscriptionPlan: {
       uuid: TEST_SUBSCRIPTION_UUID,
@@ -78,7 +78,7 @@ describe('with inactive subscription plan', () => {
     },
   };
 
-  test('renders inactive subscription plan alert if it has not started or has already ended', async () => {
+  test('renders alert if it has not started or has already ended', async () => {
     const Component = <UserSubsidyWithAppContext contextValue={contextValue} />;
     renderWithRouter(Component, {
       route: `/${TEST_ENTERPRISE_SLUG}`,
@@ -93,7 +93,7 @@ describe('with inactive subscription plan', () => {
   });
 });
 
-describe('with active subscription plan', () => {
+describe('with subscription plan that has started, but not yet ended', () => {
   const contextValue = {
     subscriptionPlan: {
       uuid: TEST_SUBSCRIPTION_UUID,

--- a/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import { screen, waitFor } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import '@testing-library/jest-dom/extend-expect';
@@ -14,6 +15,8 @@ jest.mock('../data/service');
 const TEST_SUBSCRIPTION_UUID = 'test-subscription-uuid';
 const TEST_LICENSE_UUID = 'test-license-uuid';
 const TEST_ENTERPRISE_SLUG = 'test-enterprise-slug';
+
+const now = moment();
 
 // eslint-disable-next-line react/prop-types
 const UserSubsidyWithAppContext = ({ contextValue = {} }) => (
@@ -66,9 +69,37 @@ describe('without subscription plan', () => {
   });
 });
 
-describe('with subscription plan', () => {
+describe('with inactive subscription plan', () => {
   const contextValue = {
-    subscriptionPlan: { uuid: TEST_SUBSCRIPTION_UUID },
+    subscriptionPlan: {
+      uuid: TEST_SUBSCRIPTION_UUID,
+      startDate: now.subtract(1, 'w').toISOString(),
+      expirationDate: now.subtract(1, 'd').toISOString(),
+    },
+  };
+
+  test('renders inactive subscription plan alert if it has not started or has already ended', async () => {
+    const Component = <UserSubsidyWithAppContext contextValue={contextValue} />;
+    renderWithRouter(Component, {
+      route: `/${TEST_ENTERPRISE_SLUG}`,
+    });
+
+    // assert status alert message renders
+    await waitFor(() => {
+      const activationMessage = 'does not have an active subscription plan';
+      expect(screen.queryByRole('alert')).toBeInTheDocument();
+      expect(screen.queryByText(activationMessage, { exact: false })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('with active subscription plan', () => {
+  const contextValue = {
+    subscriptionPlan: {
+      uuid: TEST_SUBSCRIPTION_UUID,
+      startDate: now.subtract(1, 'w').toISOString(),
+      expirationDate: now.add(1, 'y').toISOString(),
+    },
   };
 
   beforeEach(() => {

--- a/src/components/license-activation/LicenseActivation.jsx
+++ b/src/components/license-activation/LicenseActivation.jsx
@@ -50,7 +50,6 @@ export default function LicenseActivation() {
     <>
       <Helmet title={PAGE_TITLE} />
       <div className="container-fluid py-5">
-        <p>{LOADING_MESSAGE}</p>
         <LoadingSpinner screenReaderText={LOADING_MESSAGE} />
       </div>
     </>

--- a/src/components/license-activation/tests/LicenseActivation.test.jsx
+++ b/src/components/license-activation/tests/LicenseActivation.test.jsx
@@ -37,8 +37,8 @@ describe('LicenseActivation', () => {
       route: TEST_ROUTE,
     });
 
-    // assert component is initially loading and displays the loading message as text and SR text
-    expect(screen.queryAllByText(LOADING_MESSAGE)).toHaveLength(2);
+    // assert component is initially loading and displays the loading message as screenreader text
+    expect(screen.queryAllByText(LOADING_MESSAGE)).toHaveLength(1);
 
     // assert we did NOT get redirected
     expect(history.location.pathname).toEqual(TEST_ROUTE);

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -37,3 +37,8 @@ export const hasTruthyValue = (value) => {
   const values = createArrayFromValue(value);
   return values.every(item => !!item);
 };
+
+export const hasValidStartExpirationDates = ({ startDate, expirationDate }) => {
+  const now = moment();
+  return now.isBetween(startDate, expirationDate);
+};


### PR DESCRIPTION
This PR updates the course sidebar to include the pacing type of the course (self or instructor paced), and also adds logic to show the correct price as well.

While our current use case is to only support licenses, support for codes/offers will be coming soon in the LP. So, I tried to ensure the price messaging has a decent starting point when that work gets picked up.

Takes into account whether the EnterpriseCustomer has `hide_course_original_price` enabled.

This PR also adds date validation when retrieving whether the Enterprise Customer has an active subscription. Before, the validation was only around the `is_active` attribute. Now, it factors in whether today's date is between the subscription plan's start and expiration dates.

_**Note: Course page Tests coming in follow-up PR.**_

### Pacing type

<img width="400" src="https://user-images.githubusercontent.com/2828721/88290497-dfe1e080-ccc4-11ea-880a-0b988d2b4894.png" />

### No active subscription plan error alert

![image](https://user-images.githubusercontent.com/2828721/88289492-4fef6700-ccc3-11ea-9148-1eb986f5d223.png)

### With Subscription License:

<img width="400" src="https://user-images.githubusercontent.com/2828721/88223395-64851e00-cc35-11ea-869b-d4fedf080947.png" />

### With a fully discounted price through other subsidies (e.g., codes/offers):

<img width="400" src="https://user-images.githubusercontent.com/2828721/88230119-cea2c080-cc3f-11ea-95f3-65fb54cc87c5.png" />

### With a partially discounted price through other subsidies (e.g., codes/offers):

<img width="400" src="https://user-images.githubusercontent.com/2828721/88230552-9a7bcf80-cc40-11ea-89d8-3df7603b3022.png" />

### With no subsidy available for user:

Show list price as a last resort.

<img width="400" src="https://user-images.githubusercontent.com/2828721/88230665-d1ea7c00-cc40-11ea-87f1-30fb8d4cdd23.png" />