### PR TITLE
fix double enroll and missing hook dependencies

### DIFF
--- a/src/components/course/EnrollButton.jsx
+++ b/src/components/course/EnrollButton.jsx
@@ -70,7 +70,7 @@ export default function EnrollButton() {
       // licenses. as such, the enrollment url for codes/offers is unknown at this time.
       return null;
     },
-    [],
+    [subscriptionLicense, enterpriseConfig, key],
   );
 
   const renderButtonLabel = () => {
@@ -100,17 +100,19 @@ export default function EnrollButton() {
       }
       return (
         <>
-          <span className="enroll-btn-label">Enroll</span>
           {isArchived(activeCourseRun) ? (
             <span className="enroll-btn-label">Enroll</span>
           ) : (
-            <div>
-              <small>
-                {isCourseStarted ? 'Started' : 'Starts'}
-                {' '}
-                {moment(start).format('MMM D, YYYY')}
-              </small>
-            </div>
+            <>
+              <span className="enroll-btn-label">Enroll</span>
+              <div>
+                <small>
+                  {isCourseStarted ? 'Started' : 'Starts'}
+                  {' '}
+                  {moment(start).format('MMM D, YYYY')}
+                </small>
+              </div>
+            </>
           )}
         </>
       );


### PR DESCRIPTION
### Double "Enroll" in the button label

After a recent change, there was a certain scenario that would render "EnrollEnroll" in the button label. This PR introduces a fix for this logic to properly render just "Enroll".

[Example](https://enterprise.stage.edx.org/pied-piper/course/edx+jpm_cred103)

<img width="300" src="https://user-images.githubusercontent.com/2828721/88749492-66614c80-d121-11ea-87e8-035a72046c99.png" />

### Disabled "Enroll" button race condition

The `useMemo` hook for generating the "Enroll" button's `enrollmentUrl` returns `null` when the user's subscription license is not yet loaded. This is due to missing items in the dependency list for the `useMemo` hook, which will now properly re-generate the `enrollmentUrl` when the subscription license has loaded in, or any of the other dependent variables are changed.

<img width="300" src="https://user-images.githubusercontent.com/2828721/88749004-63199100-d120-11ea-8df0-20a8c5b5b75e.png" />
