### PR TITLE
fix page load before subsidy check resolves

### DIFF
--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -20,7 +20,12 @@ export function useSubscriptionLicenseForUser(subscriptionPlan) {
       return;
     }
 
-    if (isDefinedAndNotNull(subscriptionPlan) && hasValidStartExpirationDates(subscriptionPlan)) {
+    if (isDefinedAndNotNull(subscriptionPlan)) {
+      if (!hasValidStartExpirationDates(subscriptionPlan)) {
+        setIsLoading(false);
+        return;
+      }
+
       fetchSubscriptionLicensesForUser(subscriptionPlan.uuid)
         .then((response) => {
           const { results } = camelCaseObject(response.data);

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -4,42 +4,48 @@ import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import { LICENSE_STATUS } from './constants';
 import { fetchSubscriptionLicensesForUser } from './service';
-import { hasValidStartExpirationDates } from '../../../utils/common';
+import {
+  hasValidStartExpirationDates,
+  isDefinedAndNotNull,
+  isDefinedAndNull,
+} from '../../../utils/common';
 
 export function useSubscriptionLicenseForUser(subscriptionPlan) {
   const [license, setLicense] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (!subscriptionPlan || !hasValidStartExpirationDates(subscriptionPlan)) {
+    if (isDefinedAndNull(subscriptionPlan)) {
       setIsLoading(false);
       return;
     }
 
-    fetchSubscriptionLicensesForUser(subscriptionPlan.uuid)
-      .then((response) => {
-        const { results } = camelCaseObject(response.data);
-        const activated = results.filter(result => result.status === LICENSE_STATUS.ACTIVATED);
-        const assigned = results.filter(result => result.status === LICENSE_STATUS.ASSIGNED);
-        const deactivated = results.filter(result => result.status === LICENSE_STATUS.DEACTIVATED);
+    if (isDefinedAndNotNull(subscriptionPlan) && hasValidStartExpirationDates(subscriptionPlan)) {
+      fetchSubscriptionLicensesForUser(subscriptionPlan.uuid)
+        .then((response) => {
+          const { results } = camelCaseObject(response.data);
+          const activated = results.filter(result => result.status === LICENSE_STATUS.ACTIVATED);
+          const assigned = results.filter(result => result.status === LICENSE_STATUS.ASSIGNED);
+          const deactivated = results.filter(result => result.status === LICENSE_STATUS.DEACTIVATED);
 
-        if (activated.length) {
-          setLicense(activated.pop());
-        } else if (assigned.length) {
-          setLicense(assigned.pop());
-        } else if (deactivated.length) {
-          setLicense(deactivated.pop());
-        } else {
+          if (activated.length) {
+            setLicense(activated.pop());
+          } else if (assigned.length) {
+            setLicense(assigned.pop());
+          } else if (deactivated.length) {
+            setLicense(deactivated.pop());
+          } else {
+            setLicense(null);
+          }
+        })
+        .catch((error) => {
+          logError(new Error(error));
           setLicense(null);
-        }
-      })
-      .catch((error) => {
-        logError(new Error(error));
-        setLicense(null);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
   }, [subscriptionPlan]);
 
   return [license, isLoading];

--- a/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
@@ -16,8 +16,6 @@ const TEST_SUBSCRIPTION_UUID = 'test-subscription-uuid';
 const TEST_LICENSE_UUID = 'test-license-uuid';
 const TEST_ENTERPRISE_SLUG = 'test-enterprise-slug';
 
-const now = moment();
-
 // eslint-disable-next-line react/prop-types
 const UserSubsidyWithAppContext = ({ contextValue = {} }) => (
   <AppContext.Provider
@@ -70,15 +68,17 @@ describe('without subscription plan', () => {
 });
 
 describe('with subscription plan that is expired or has not yet started', () => {
+  const startDate = moment().subtract(1, 'y');
+  const expirationDate = moment().subtract(1, 'w');
   const contextValue = {
     subscriptionPlan: {
       uuid: TEST_SUBSCRIPTION_UUID,
-      startDate: now.subtract(1, 'w').toISOString(),
-      expirationDate: now.subtract(1, 'd').toISOString(),
+      startDate: startDate.toISOString(),
+      expirationDate: expirationDate.toISOString(),
     },
   };
 
-  test('renders alert if it has not started or has already ended', async () => {
+  test('renders alert if plan has not started or has already ended', async () => {
     const Component = <UserSubsidyWithAppContext contextValue={contextValue} />;
     renderWithRouter(Component, {
       route: `/${TEST_ENTERPRISE_SLUG}`,
@@ -97,8 +97,8 @@ describe('with subscription plan that has started, but not yet ended', () => {
   const contextValue = {
     subscriptionPlan: {
       uuid: TEST_SUBSCRIPTION_UUID,
-      startDate: now.subtract(1, 'w').toISOString(),
-      expirationDate: now.add(1, 'y').toISOString(),
+      startDate: moment().subtract(1, 'w').toISOString(),
+      expirationDate: moment().add(1, 'y').toISOString(),
     },
   };
 


### PR DESCRIPTION
This PR addresses an issue where the page content flashes prior to loading the subscription plan/license subsidy.

### Testing Instructions

1. With an active subscription plan and an unassigned license, browse to the LP search page.
2. You should **NOT** see a flash of the "Search" page before getting redirected to the home page. Instead, you _should_ see a loading spinner below the branded enterprise banner.