### PR TITLE
hide partner logo wrapper if there's no logo to display

### DIFF
--- a/src/components/search/SearchCourseCard.jsx
+++ b/src/components/search/SearchCourseCard.jsx
@@ -69,18 +69,20 @@ const SearchCourseCard = ({ hit, isLoading }) => {
               alt=""
             />
           )}
-          <div className="partner-logo-wrapper">
-            {isLoading && (
+          {isLoading && (
+            <div className="partner-logo-wrapper">
               <Skeleton width={90} height={42} data-testid="partner-logo-loading" />
-            )}
-            {!isLoading && partnerDetails.primaryPartner && partnerDetails.showPartnerLogo && (
+            </div>
+          )}
+          {!isLoading && partnerDetails.primaryPartner && partnerDetails.showPartnerLogo && (
+            <div className="partner-logo-wrapper">
               <img
                 src={partnerDetails.primaryPartner.logoImageUrl}
                 className="partner-logo"
                 alt={partnerDetails.primaryPartner.name}
               />
-            )}
-          </div>
+            </div>
+          )}
           <div className="card-body py-3">
             <h3 className="card-title h5 mb-1">
               {isLoading ? (


### PR DESCRIPTION
This PR fixes the issue where a white box is displayed on course cards when there is no partner logo to show, as in the case described by ENT-3266.

<img width="300" src="https://user-images.githubusercontent.com/2828721/88811697-e076ed00-d184-11ea-8726-4adb8880797a.png" />
