### PR TITLE
refactor for new saved_for_later course status and is_revoked flag

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -15,11 +15,9 @@ import {
   SavedForLaterCourseCard,
 } from './course-cards';
 
+import { COURSE_STATUSES } from './data/constants';
 import * as selectors from './data/selectors';
 import * as actions from './data/actions';
-
-const SAVED_FOR_LATER_COURSES_SECTION_SUBTITLE = `This section contains both the courses you have completed
-  in the past and courses that have been voluntarily removed from your "In Progress" list.`;
 
 export const COURSE_SECTION_TITLES = {
   inProgress: 'My courses in progress',
@@ -54,10 +52,10 @@ export class CourseEnrollments extends Component {
   }
 
   hasCourseRuns = () => (
-    this.hasCourseRunsWithStatus('completed')
-    || this.hasCourseRunsWithStatus('in_progress')
-    || this.hasCourseRunsWithStatus('upcoming')
-    || this.hasCourseRunsWithStatus('savedForLater')
+    this.hasCourseRunsWithStatus(COURSE_STATUSES.completed)
+    || this.hasCourseRunsWithStatus(COURSE_STATUSES.inProgress)
+    || this.hasCourseRunsWithStatus(COURSE_STATUSES.upcoming)
+    || this.hasCourseRunsWithStatus(COURSE_STATUSES.savedForLater)
   )
 
   renderError = () => (
@@ -163,15 +161,13 @@ export class CourseEnrollments extends Component {
         />
         <CourseSection
           title={COURSE_SECTION_TITLES.completed}
-          subtitle={SAVED_FOR_LATER_COURSES_SECTION_SUBTITLE}
           component={CompletedCourseCard}
           courseRuns={courseRuns.completed}
         />
         <CourseSection
           title={COURSE_SECTION_TITLES.savedForLater}
-          subtitle={SAVED_FOR_LATER_COURSES_SECTION_SUBTITLE}
           component={SavedForLaterCourseCard}
-          courseRuns={courseRuns.savedForLater}
+          courseRuns={courseRuns.saved_for_later}
         />
       </>
     );
@@ -210,7 +206,7 @@ CourseEnrollments.propTypes = {
     in_progress: PropTypes.array.isRequired,
     upcoming: PropTypes.array.isRequired,
     completed: PropTypes.array.isRequired,
-    savedForLater: PropTypes.array.isRequired,
+    saved_for_later: PropTypes.array.isRequired,
   }).isRequired,
   isLoading: PropTypes.bool.isRequired,
   isMarkCourseCompleteSuccess: PropTypes.bool.isRequired,

--- a/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
@@ -12,6 +12,8 @@ import {
 } from './course-cards';
 import CollapsibleIcon from './CollapsibleIcon';
 
+import { COURSE_STATUSES } from './data/constants';
+
 import './styles/CourseSection.scss';
 
 class CourseSection extends React.Component {
@@ -39,18 +41,20 @@ class CourseSection extends React.Component {
     linkToCertificate,
     notifications,
     courseRunStatus,
-    savedForLater,
+    isRevoked,
     ...rest
   }) => {
     const courseRunProps = { courseRunStatus };
     switch (courseRunStatus) {
-      case 'in_progress':
+      case COURSE_STATUSES.inProgress:
         courseRunProps.linkToCertificate = linkToCertificate;
         courseRunProps.notifications = notifications;
         break;
-      case 'completed':
+      case COURSE_STATUSES.savedForLater:
+        courseRunProps.isRevoked = isRevoked;
+        break;
+      case COURSE_STATUSES.completed:
         courseRunProps.linkToCertificate = linkToCertificate;
-        courseRunProps.savedForLater = savedForLater;
         break;
       default:
         break;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -11,6 +11,8 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 import { EmailSettingsModal } from './email-settings';
 
+import { COURSE_STATUSES } from '../data/constants';
+
 import './styles/CourseCard.scss';
 
 class BaseCourseCard extends Component {
@@ -55,7 +57,7 @@ class BaseCourseCard extends Component {
     let message = '';
     if (formattedEndDate) {
       switch (type) {
-        case 'in_progress': {
+        case COURSE_STATUSES.inProgress: {
           if (pacing === 'self') {
             message += `Complete at your own speed before ${formattedEndDate}.`;
           } else {
@@ -63,12 +65,12 @@ class BaseCourseCard extends Component {
           }
           break;
         }
-        case 'upcoming': {
-          message += `Ends ${formattedEndDate}.`;
-          break;
-        }
-        case 'completed': {
-          message += `Ended ${formattedEndDate}.`;
+        case COURSE_STATUSES.upcoming:
+        case COURSE_STATUSES.completed:
+        case COURSE_STATUSES.savedForLater: {
+          const isCourseEnded = moment() > moment(endDate);
+          message += isCourseEnded ? 'Ended' : 'Ends';
+          message += ` ${formattedEndDate}.`;
           break;
         }
         default:
@@ -308,7 +310,7 @@ class BaseCourseCard extends Component {
 
 BaseCourseCard.propTypes = {
   type: PropTypes.oneOf([
-    'in_progress', 'upcoming', 'completed',
+    'in_progress', 'upcoming', 'completed', 'saved_for_later',
   ]).isRequired,
   title: PropTypes.string.isRequired,
   linkToCourse: PropTypes.string.isRequired,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
@@ -16,12 +16,14 @@ const CompletedCourseCard = (props) => {
     title,
     linkToCourse,
     courseRunId,
-    courseRunStatus,
     endDate,
   } = props;
 
   const renderButtons = () => {
-    if (isCourseEnded(endDate) || courseRunStatus === 'completed') { return null; }
+    if (isCourseEnded(endDate)) {
+      return null;
+    }
+
     return (
       <ContinueLearningButton
         linkToCourse={linkToCourse}
@@ -76,7 +78,6 @@ CompletedCourseCard.propTypes = {
   courseRunId: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   linkToCertificate: PropTypes.string,
-  savedForLater: PropTypes.bool.isRequired,
   courseRunStatus: PropTypes.string.isRequired,
   endDate: PropTypes.string,
 };

--- a/src/components/dashboard/main-content/course-enrollments/data/constants.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/constants.js
@@ -9,5 +9,5 @@ export const COURSE_STATUSES = {
   inProgress: 'in_progress',
   upcoming: 'upcoming',
   completed: 'completed',
-  savedForLater: 'savedForLater',
+  savedForLater: 'saved_for_later',
 };

--- a/src/components/dashboard/main-content/course-enrollments/data/selectors.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/selectors.js
@@ -41,19 +41,12 @@ export const filterCourseRuns = (courseRuns) => {
     [COURSE_STATUSES.completed]: [],
     [COURSE_STATUSES.savedForLater]: [],
   };
-  if (courseRuns && courseRuns.length > 0) {
+  if (courseRuns?.length > 0) {
     const transformedCourseRuns = courseRuns.map(transformCourseRun);
     Object.keys(courseRunsByStatus).forEach((status) => {
-      courseRunsByStatus[status] = transformedCourseRuns.filter((courseRun) => {
-        if (courseRun.courseRunStatus !== COURSE_STATUSES.completed
-          || (courseRun.courseRunStatus === COURSE_STATUSES.completed && !courseRun.savedForLater)) {
-          return courseRun.courseRunStatus === status;
-        }
-        if (status === COURSE_STATUSES.savedForLater && courseRun.savedForLater) {
-          return true;
-        }
-        return false;
-      });
+      courseRunsByStatus[status] = transformedCourseRuns.filter(
+        courseRun => courseRun.courseRunStatus === status,
+      );
     });
   }
   return courseRunsByStatus;

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/selectors.test.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/selectors.test.js
@@ -1,36 +1,31 @@
-import {
-  filterCourseRuns,
-} from '../selectors';
+import { filterCourseRuns } from '../selectors';
 import { COURSE_STATUSES } from '../constants';
+
 import { createRawCourseRun } from '../../tests/enrollment-testutils';
 
 describe('filterCourseRunsByStatus', () => {
-  it('categorizes in_progress and upcoming courses correctly', () => {
+  it('categorizes courses into the correct course section based on status', () => {
     const inProgressCourse = createRawCourseRun();
     const upcomingCourse = { ...createRawCourseRun(), courseRunStatus: COURSE_STATUSES.upcoming };
-    const result = filterCourseRuns([inProgressCourse, upcomingCourse]);
-    expect(result.in_progress[0].courseRunStatus).toEqual(COURSE_STATUSES.inProgress);
+    const completedCourse = { ...createRawCourseRun(), courseRunStatus: COURSE_STATUSES.completed };
+    const savedForLaterCourse = { ...createRawCourseRun(), courseRunStatus: COURSE_STATUSES.savedForLater };
+    const result = filterCourseRuns([
+      inProgressCourse,
+      upcomingCourse,
+      completedCourse,
+      savedForLaterCourse,
+    ]);
+
     expect(result.in_progress.length).toEqual(1);
+    expect(result.in_progress[0].courseRunStatus).toEqual(COURSE_STATUSES.inProgress);
+
     expect(result.upcoming.length).toEqual(1);
     expect(result.upcoming[0].courseRunStatus).toEqual(COURSE_STATUSES.upcoming);
-    expect(result.completed.length).toEqual(0);
-    expect(result.savedForLater.length).toEqual(0);
-  });
-  it('categorizes completed and saved for later courses correctly', () => {
-    const completedCourse = { ...createRawCourseRun(), courseRunStatus: COURSE_STATUSES.completed };
-    const savedForLaterCourse = {
-      ...createRawCourseRun(),
-      courseRunStatus: COURSE_STATUSES.completed,
-      savedForLater: true,
-    };
-    const result = filterCourseRuns([completedCourse, savedForLaterCourse]);
-    expect(result.completed[0].courseRunStatus).toEqual(COURSE_STATUSES.completed);
-    expect(result.completed[0].savedForLater).toEqual(false);
+
     expect(result.completed.length).toEqual(1);
-    expect(result.savedForLater.length).toEqual(1);
-    expect(result.savedForLater[0].courseRunStatus).toEqual(COURSE_STATUSES.completed);
-    expect(result.savedForLater[0].savedForLater).toEqual(true);
-    expect(result.in_progress.length).toEqual(0);
-    expect(result.upcoming.length).toEqual(0);
+    expect(result.completed[0].courseRunStatus).toEqual(COURSE_STATUSES.completed);
+
+    expect(result.saved_for_later.length).toEqual(1);
+    expect(result.saved_for_later[0].courseRunStatus).toEqual(COURSE_STATUSES.savedForLater);
   });
 });

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.enzyme.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.enzyme.test.jsx
@@ -26,7 +26,7 @@ describe('<CourseEnrollments />', () => {
       in_progress: [],
       upcoming: [],
       completed: [],
-      savedForLater: [],
+      saved_for_later: [],
     },
     isLoading: false,
     error: null,
@@ -61,7 +61,7 @@ describe('<CourseEnrollments />', () => {
         startDate: '2017-02-05T05:00:00Z',
         endDate: '2018-08-18T05:00:00Z',
         hasEmailsEnabled: true,
-        savedForLater: false,
+        is_revoked: false,
       };
       const courseRuns = {
         in_progress: [{
@@ -78,7 +78,7 @@ describe('<CourseEnrollments />', () => {
         }],
         upcoming: [],
         completed: [sampleCourseRun],
-        savedForLater: [],
+        saved_for_later: [],
       };
       const enterpriseConfig = {
         uuid: 'test-program-uuid',

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -37,7 +37,7 @@ const enterpriseConfig = {
 };
 const completedCourseRun = createCompletedCourseRun();
 const inProgCourseRun = { ...completedCourseRun, courseRunStatus: COURSE_STATUSES.inProgress };
-const savedForLaterCourseRun = { ...completedCourseRun, savedForLater: true };
+const savedForLaterCourseRun = { ...completedCourseRun, courseRunStatus: COURSE_STATUSES.savedForLater };
 
 const defaultInitialProps = defaultInitialEnrollmentProps({ genericMockFn });
 
@@ -47,7 +47,7 @@ const initProps = {
     in_progress: [inProgCourseRun],
     upcoming: [],
     completed: [completedCourseRun],
-    savedForLater: [savedForLaterCourseRun],
+    saved_for_later: [savedForLaterCourseRun],
   },
 };
 
@@ -60,13 +60,15 @@ function renderEnrollmentsComponent(initialProps) {
     </Provider>,
   );
 }
-describe('Course enrollements', () => {
+describe('Course enrollments', () => {
   beforeEach(() => {
     updateCourseCompleteStatusRequest.mockImplementation(() => {});
   });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
+
   test('loads enrollments component', () => {
     renderEnrollmentsComponent(initProps);
     expect(screen.getByText(COURSE_SECTION_TITLES.inProgress)).toBeInTheDocument();

--- a/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
+++ b/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
@@ -35,7 +35,7 @@ const createCompletedCourseRun = () => {
     startDate: '2017-02-05T05:00:00Z',
     endDate: '2018-08-18T05:00:00Z',
     hasEmailsEnabled: true,
-    savedForLater: false,
+    isRevoked: false,
   };
   return completedCourseRun;
 };
@@ -49,7 +49,7 @@ const createRawCourseRun = () => ({
   dueDates: [],
   completed: false,
   courseRunStatus: COURSE_STATUSES.inProgress,
-  savedForLater: false,
+  isRevoked: false,
 });
 
 /**

--- a/src/components/enterprise-user-subsidy/UserSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidy.jsx
@@ -5,7 +5,6 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { LoadingSpinner } from '../loading-spinner';
 import SubscriptionSubsidy from './SubscriptionSubsidy';
 
-import { isNull, hasValidStartExpirationDates } from '../../utils/common';
 import { useSubscriptionLicenseForUser } from './data/hooks';
 import { LICENSE_STATUS, LOADING_SCREEN_READER_TEXT } from './data/constants';
 
@@ -28,19 +27,14 @@ const UserSubsidy = ({ children }) => {
       let hasAccessToPortal = true;
 
       // determine whether user has access to the Learner Portal if their organization
-      // has an active Subscription Plan.
-      if (!subscriptionPlan || !hasValidStartExpirationDates(subscriptionPlan)) {
-        hasAccessToPortal = false;
-      }
-
-      // determine whether user has access to the Learner Portal if they have an activated license
-      if (isNull(subscriptionLicense) || subscriptionLicense?.status !== LICENSE_STATUS.ACTIVATED) {
-        hasAccessToPortal = false;
+      // has a Subscription Plan and whether user has an activated license.
+      if (subscriptionPlan) {
+        hasAccessToPortal = subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED;
       }
 
       return { hasAccessToPortal, subscriptionLicense };
     },
-    [subscriptionLicense],
+    [subscriptionPlan, subscriptionLicense],
   );
 
   if (isLoadingSubsidies) {


### PR DESCRIPTION
Ticket: https://openedx.atlassian.net/browse/ENT-2891

This PR refactors the logic around the "saved for later" course run status to reflect the changes in this related edx-enterprise PR: https://github.com/edx/edx-enterprise/pull/914/.

Before, "Saved for later" courses were returning as "completed" and logic existed to change the course run status from "completed" to "saved for later" based on the `saved_for_later` flag on the enterprise course enrollment. However, in the linked edx-enterprise PR, a new `saved_for_later` status is introduced that can be used instead of the logic within the UI.

Additionally, this PR does some UX clean up to prevent moving a "revoked" course enrollment back to in-progress (hides the "Move to In Progress" option in the gear), and updates the `SavedForLaterCourseCard` component, which previously rendered UI related to "Completed" courses, which should only belong in the `CompletedCourseCard` component.