### PR TITLE
Add alert for enterprise offers

### DIFF
--- a/src/components/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/dashboard/sidebar/DashboardSidebar.jsx
@@ -10,7 +10,10 @@ import SidebarCard from './SidebarCard';
 
 class DashboardSidebar extends React.Component {
   componentDidMount() {
-    this.props.fetchOffers('full_discount_only=True');
+    const { isOffersLoading } = this.props;
+    if (!isOffersLoading) {
+      this.props.fetchOffers('full_discount_only=True');
+    }
   }
 
   renderContactHelpText() {

--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -1,11 +1,11 @@
 import React, { useContext } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
+import OffersAlert from './OffersAlert';
 
 import './styles/EnterpriseBanner.scss';
 
 export default function EnterpriseBanner() {
   const { enterpriseConfig } = useContext(AppContext);
-
   return (
     <div className="enterprise-banner bg-brand-secondary">
       <div className="container-fluid">
@@ -13,6 +13,7 @@ export default function EnterpriseBanner() {
           {enterpriseConfig.name}
         </h1>
       </div>
+      <OffersAlert />
     </div>
   );
 }

--- a/src/components/enterprise-banner/OffersAlert.jsx
+++ b/src/components/enterprise-banner/OffersAlert.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Alert } from '@edx/paragon';
+
+import { fetchOffers } from '../dashboard/sidebar/offers';
+
+export const getOffersText = (number) => `You have ${number} offers available.`;
+
+export class BaseOffersAlert extends React.Component {
+  componentDidMount() {
+    const { isOffersLoading, fetchOffersAction } = this.props;
+
+    if (!isOffersLoading) {
+      fetchOffersAction('full_discount_only=True');
+    }
+  }
+
+  render() {
+    const { offersCount } = this.props;
+    return (
+      <>{offersCount && (
+        <Alert
+          className="pl-5"
+          variant="info"
+        >
+          <div className="container">{getOffersText(offersCount)}</div>
+        </Alert>
+      )}
+      </>
+    );
+  }
+}
+
+BaseOffersAlert.defaultProps = {
+  fetchOffersAction: null,
+  isOffersLoading: false,
+  offersCount: 0,
+};
+
+BaseOffersAlert.propTypes = {
+  fetchOffersAction: PropTypes.func,
+  isOffersLoading: PropTypes.bool,
+  offersCount: PropTypes.number,
+};
+
+const mapStateToProps = state => ({
+  isOffersLoading: state.offers.loading,
+  offersCount: state.offers.offersCount,
+  timeFetched: state.offers.timeFetched,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchOffersAction: (query) => (query ? dispatch(fetchOffers(query)) : dispatch(fetchOffers())),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(BaseOffersAlert);

--- a/src/components/enterprise-banner/OffersAlert.test.jsx
+++ b/src/components/enterprise-banner/OffersAlert.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { BaseOffersAlert, getOffersText } from './OffersAlert';
+
+describe('<OffersAlert />', () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      fetchOffersAction: jest.fn(),
+      isOffersLoading: false,
+      offersCount: 5,
+    };
+  });
+  it('fetches offers on mount', () => {
+    render(<BaseOffersAlert {...props} />);
+    expect(props.fetchOffersAction).toHaveBeenCalledTimes(1);
+  });
+  it('does not fetch offers if offers are loading', () => {
+    render(<BaseOffersAlert {...props} isOffersLoading />);
+    expect(props.fetchOffersAction).toHaveBeenCalledTimes(0);
+  });
+  it('renders an alert when loading is complete and there are offers', () => {
+    render(<BaseOffersAlert {...props} />);
+    expect(screen.queryByText(getOffersText(props.offersCount))).toBeInTheDocument();
+  });
+  it('does not render an alert if there are no offers', () => {
+    render(<BaseOffersAlert {...props} offersCount={0} />);
+    expect(screen.queryByText(getOffersText(props.offersCount))).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Alert is for 100% enterprise offers only
Ensures that the API call is only made once on pages where the sidebar is present

Miro Board: https://miro.com/app/board/o9J_kp-7aks=/?moveToWidget=3074457348784458838&cot=13
*Note* I made the decision to include this on the learner portal dashboard because the sidebar that shows the coupon count currently disappears on mobile.

Instructions for creating offers: https://github.com/edx/ecommerce/pull/3082