### PR TITLE
remove .btn-brand-primary class from course run selector

### DIFF
--- a/src/components/course/CourseRunSelector.jsx
+++ b/src/components/course/CourseRunSelector.jsx
@@ -24,9 +24,13 @@ export default function CourseRunSelector() {
   if (multipleRunsAvailable) {
     if (!editing) {
       return (
-        <button type="button" onClick={() => setEditing(true)} className="btn btn-link mb-1 p-0 btn-brand-primary">
+        <Button
+          buttonType="link"
+          onClick={() => setEditing(true)}
+          className="mb-1 p-0"
+        >
           more dates
-        </button>
+        </Button>
       );
     }
     return (


### PR DESCRIPTION
The course run selector's "more dates" button is currently using the `.btn-brand-primary` class when it should just remain as `.btn-link`:

### Before
<img src="https://user-images.githubusercontent.com/2828721/92661176-00dcb000-f2ca-11ea-8be9-bce2cd6f0ab5.png" width="300" />

### After
<img src="https://user-images.githubusercontent.com/2828721/92661428-a2640180-f2ca-11ea-9686-37a8a8c7c5e7.png" width="300" />

