### PR TITLE
(EnrollButton) fixing redundant use of button success style class

### DIFF
--- a/src/components/course/DeprecatedEnrollButton.jsx
+++ b/src/components/course/DeprecatedEnrollButton.jsx
@@ -48,7 +48,7 @@ export default function EnrollButton() {
     courseUuid,
   } = activeCourseRun;
 
-  const enrollLinkClass = 'btn-success btn-block rounded-0 py-2';
+  const enrollLinkClass = 'btn-block rounded-0 py-2';
 
   const isCourseStarted = useMemo(
     () => hasCourseStarted(start),
@@ -145,14 +145,19 @@ export default function EnrollButton() {
       if (enrollmentUrl) {
         return (
           <a
-            className={classNames('btn', enrollLinkClass)}
+            className={classNames('btn', 'btn-success', enrollLinkClass)}
             href={enrollmentUrl}
           >
             {renderButtonLabel()}
           </a>
         );
       }
-      return <DefaultEnrollCta className={classNames(enrollLinkClass, 'disabled')} />;
+      return (
+        <DefaultEnrollCta
+          className={classNames(enrollLinkClass, 'disabled')}
+          variant="success"
+        />
+      );
     }
 
     if (!isUserEnrolled && !isEnrollable) {
@@ -167,7 +172,7 @@ export default function EnrollButton() {
       if (isCourseStarted) {
         return (
           <a
-            className={classNames('btn', enrollLinkClass)}
+            className={classNames('btn', 'btn-success', enrollLinkClass)}
             href={`${process.env.LMS_BASE_URL}/courses/${key}/info`}
           >
             {renderButtonLabel()}
@@ -177,7 +182,7 @@ export default function EnrollButton() {
 
       return (
         <Link
-          className={classNames('btn', enrollLinkClass)}
+          className={classNames('btn', 'btn-success', enrollLinkClass)}
           to={`/${enterpriseConfig.slug}`}
         >
           {renderButtonLabel()}
@@ -185,7 +190,12 @@ export default function EnrollButton() {
       );
     }
 
-    return <DefaultEnrollCta className={enrollLinkClass} />;
+    return (
+      <DefaultEnrollCta
+        className={enrollLinkClass}
+        variant="success"
+      />
+    );
   };
 
   return (

--- a/src/components/course/EnrollButton.jsx
+++ b/src/components/course/EnrollButton.jsx
@@ -133,7 +133,7 @@ export default function EnrollButton() {
     seats,
   } = activeCourseRun;
 
-  const enrollLinkClass = 'btn-success btn-block rounded-0 py-2';
+  const enrollLinkClass = 'btn-block rounded-0 py-2';
   const sku = useMemo(
     () => findHighestLevelSeatSku(seats),
     [seats],
@@ -188,7 +188,7 @@ export default function EnrollButton() {
       if (enrollmentUrl && subscriptionLicense) {
         return (
           <a
-            className={classNames('btn', enrollLinkClass)}
+            className={classNames('btn', 'btn-success', enrollLinkClass)}
             href={enrollmentUrl}
           >
             <EnrollButtonLabel
@@ -210,6 +210,7 @@ export default function EnrollButton() {
             <Button
               className={classNames('btn', enrollLinkClass)}
               onClick={() => setIsModalOpen(true)}
+              variant="success"
             >
               <EnrollButtonLabel
                 activeCourseRun={activeCourseRun}
@@ -263,7 +264,7 @@ export default function EnrollButton() {
       if (isCourseStarted) {
         return (
           <a
-            className={classNames('btn', enrollLinkClass)}
+            className={classNames('btn', 'btn-success', enrollLinkClass)}
             href={`${process.env.LMS_BASE_URL}/courses/${key}/info`}
           >
             <EnrollButtonLabel
@@ -283,7 +284,7 @@ export default function EnrollButton() {
 
       return (
         <Link
-          className={classNames('btn', enrollLinkClass)}
+          className={classNames('btn', 'btn-success', enrollLinkClass)}
           to={`/${enterpriseConfig.slug}`}
         >
           <EnrollButtonLabel


### PR DESCRIPTION
Now that the paragon `Button` component accepts the `variant` prop, the `btn-success` style class shouldn't be passed as part of `className` to any `Button` with `variant="success"`. 

Since `btn-success` is no longer part of `enrollLinkClass` it must be passed as an additional argument to `classNames()` when `enrollLinkClass` is used for anchor tags and `Link` components.