### PR TITLE
 fix mobile search filters styles and prevent JS error

### DIFF
--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -43,6 +43,7 @@ export const COURSE_MODES_MAP = {
   PROFESSIONAL: 'professional',
   NO_ID_PROFESSIONAL: 'no-id-professional',
   AUDIT: 'audit',
+  HONOR: 'honor',
 };
 
 export const ENROLLMENT_FAILED_QUERY_PARAM = 'enrollment_failed';

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -135,18 +135,26 @@ export function findOfferForCourse(offers, catalogList) {
 
 const getBestCourseMode = (courseModes) => {
   const {
-    VERIFIED, PROFESSIONAL, NO_ID_PROFESSIONAL, AUDIT,
+    VERIFIED, PROFESSIONAL, NO_ID_PROFESSIONAL, AUDIT, HONOR,
   } = COURSE_MODES_MAP;
   /** Returns the 'highest' course mode available.
-    *  Modes are ranked ['verified', 'professional', 'no-id-professional', 'audit'] */
+    *  Modes are ranked ['verified', 'professional', 'no-id-professional', 'audit', 'honor'] */
   if (courseModes.includes(VERIFIED)) {
     return VERIFIED;
-  } if (courseModes.includes(PROFESSIONAL)) {
+  }
+  if (courseModes.includes(PROFESSIONAL)) {
     return PROFESSIONAL;
-  } if (courseModes.includes(NO_ID_PROFESSIONAL)) {
+  }
+  if (courseModes.includes(NO_ID_PROFESSIONAL)) {
     return NO_ID_PROFESSIONAL;
   }
-  return AUDIT;
+  if (courseModes.includes(AUDIT)) {
+    return AUDIT;
+  }
+  if (courseModes.includes(HONOR)) {
+    return HONOR;
+  }
+  return null;
 };
 
 export function findHighestLevelSeatSku(seats) {
@@ -156,7 +164,7 @@ export function findHighestLevelSeatSku(seats) {
   }
   const courseModes = seats.map(seat => seat.type);
   const courseMode = getBestCourseMode(courseModes);
-  return seats.find((seat) => seat.type === courseMode).sku;
+  return seats.find(seat => seat.type === courseMode)?.sku;
 }
 
 export function shouldUpgradeUserEnrollment({

--- a/src/components/search/styles/_MobileSearchFilters.scss
+++ b/src/components/search/styles/_MobileSearchFilters.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  .dropdown {
+  .facet-list .dropdown {
     @extend .mb-0;
 
     .dropdown-toggle {

--- a/src/index.scss
+++ b/src/index.scss
@@ -13,4 +13,5 @@ $fa-font-path: "~font-awesome/fonts";
 @import "./components/search/styles/FacetList";
 @import "components/search/styles/SearchCourseCard";
 @import "components/search/styles/SearchResults";
+@import "components/search/styles/MobileSearchFilters";
 @import "components/site-header/styles/Header";


### PR DESCRIPTION
Viewing a course on stage that only has a "honor" track, a JS error was being thrown due to not considering honor seats when choosing which seat the user should enroll in for offer (code) enrollments. Now, it factors in honor seats and avoids the JS error from occuring.

### Mobile Search Filters
After some recent renaming of SCSS files, we lost our import of the MobileSearchFilters.scss file, so the mobile search filter styles weren't present.

<table>
<thead>
<tr>
<th><i><u>Before</u></i></th>
<th><i><u>After</u></i></th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://user-images.githubusercontent.com/2828721/97438681-827cb180-18fb-11eb-82c8-b60ccfa5f77b.png" width="300" />
</td>
<td><img src="https://user-images.githubusercontent.com/2828721/97438577-5c571180-18fb-11eb-8a34-fa9d3a4aa3eb.png" width="300" />
</td>
</tr>
</tbody>
</table>