### PR TITLE
Fix subscription/codes query, pagination, and edit labels

### DIFF
--- a/src/components/search/FacetListFreeAll.jsx
+++ b/src/components/search/FacetListFreeAll.jsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
 
+import qs from 'query-string';
 import FacetDropdown from './FacetDropdown';
 import FacetItem from './FacetItem';
 
@@ -11,9 +13,14 @@ const FacetListFreeAll = ({
   items,
   showAllCatalogs,
   setShowAllCatalogs,
+  refinementsFromQueryParams,
 }) => {
+  const history = useHistory();
   const handleInputOnChange = () => {
+    const refinements = { ...refinementsFromQueryParams };
+    delete refinements.page; // reset to page 1
     setShowAllCatalogs(!showAllCatalogs);
+    history.push({ search: qs.stringify(refinements) });
   };
 
   const renderItems = useCallback(
@@ -49,6 +56,7 @@ FacetListFreeAll.propTypes = {
   title: PropTypes.string.isRequired,
   setShowAllCatalogs: PropTypes.func.isRequired,
   showAllCatalogs: PropTypes.bool.isRequired,
+  refinementsFromQueryParams: PropTypes.shape().isRequired,
 };
 
 export default FacetListFreeAll;

--- a/src/components/search/SearchFilters.jsx
+++ b/src/components/search/SearchFilters.jsx
@@ -68,6 +68,7 @@ const SearchFilters = () => {
               showAllCatalogs={showAllCatalogs}
               setShowAllCatalogs={setShowAllCatalogs}
               title="Free/All"
+              refinementsFromQueryParams={refinementsFromQueryParams}
             />
           )}
           {searchFacets}
@@ -81,6 +82,7 @@ const SearchFilters = () => {
                 showAllCatalogs={showAllCatalogs}
                 setShowAllCatalogs={setShowAllCatalogs}
                 title="Free/All"
+                refinementsFromQueryParams={refinementsFromQueryParams}
               />
             )}
             {searchFacets}

--- a/src/components/search/SearchFilters.jsx
+++ b/src/components/search/SearchFilters.jsx
@@ -15,6 +15,8 @@ import { useWindowSize } from '../../utils/hooks';
 import { SearchContext } from './SearchContext';
 import { features } from '../../config';
 
+export const FREE_ALL_TITLE = 'Free / All';
+
 const SearchFilters = () => {
   const size = useWindowSize();
   const { showAllCatalogs, setShowAllCatalogs } = useContext(SearchContext);
@@ -29,7 +31,7 @@ const SearchFilters = () => {
       value: !showAllCatalogs,
     },
     {
-      label: 'All Courses',
+      label: 'All courses',
       value: showAllCatalogs,
     },
   ], [showAllCatalogs]);
@@ -67,7 +69,7 @@ const SearchFilters = () => {
               items={freeAllItems}
               showAllCatalogs={showAllCatalogs}
               setShowAllCatalogs={setShowAllCatalogs}
-              title="Free/All"
+              title={FREE_ALL_TITLE}
               refinementsFromQueryParams={refinementsFromQueryParams}
             />
           )}
@@ -81,7 +83,7 @@ const SearchFilters = () => {
                 items={freeAllItems}
                 showAllCatalogs={showAllCatalogs}
                 setShowAllCatalogs={setShowAllCatalogs}
-                title="Free/All"
+                title={FREE_ALL_TITLE}
                 refinementsFromQueryParams={refinementsFromQueryParams}
               />
             )}

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -137,9 +137,13 @@ export const useDefaultSearchFilters = ({ enterpriseConfig, subscriptionPlan, of
 
   const filters = useMemo(
     () => {
+      const customerCatalogFilter = `enterprise_customer_uuids:${enterpriseConfig.uuid}`;
       if (showAllCatalogs) {
         // show all enterprise catalogs
-        return `enterprise_customer_uuids:${enterpriseConfig.uuid}`;
+        if (!subscriptionPlan) {
+          return customerCatalogFilter;
+        }
+        return `enterprise_catalog_uuids:${subscriptionPlan.enterpriseCatalogUuid} OR ${customerCatalogFilter}`;
       }
       // if there's a subscriptionPlan, filter results by the subscription catalog
       // and any catalogs for which the user has vouchers
@@ -154,7 +158,7 @@ export const useDefaultSearchFilters = ({ enterpriseConfig, subscriptionPlan, of
         // shows catalogs for which a user has 100% vouchers
         return getCatalogString(offerCatalogs);
       }
-      return `enterprise_customer_uuids:${enterpriseConfig.uuid}`;
+      return customerCatalogFilter;
     },
     [enterpriseConfig, subscriptionPlan, offerCatalogs, showAllCatalogs],
   );

--- a/src/components/search/data/tests/hooks.test.jsx
+++ b/src/components/search/data/tests/hooks.test.jsx
@@ -132,7 +132,7 @@ describe('useDefaultSearchFilters hook', () => {
       const { setShowAllCatalogs } = result.current;
       act(() => setShowAllCatalogs(true));
       const { filters } = result.current;
-      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+      expect(filters).toEqual(`enterprise_catalog_uuids:test-subscription-catalog-uuid OR enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
     });
   });
   describe('with catalogs', () => {
@@ -180,7 +180,7 @@ describe('useDefaultSearchFilters hook', () => {
       const { setShowAllCatalogs } = result.current;
       act(() => setShowAllCatalogs(true));
       const { filters } = result.current;
-      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+      expect(filters).toEqual(`enterprise_catalog_uuids:test-subscription-catalog-uuid OR enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
     });
   });
 });

--- a/src/components/search/tests/FacetListFreeAll.test.jsx
+++ b/src/components/search/tests/FacetListFreeAll.test.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { act, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { FREE_ALL_TITLE } from '../SearchFilters';
 
 import FacetListFreeAll from '../FacetListFreeAll';
 import { FACET_ATTRIBUTES, SUBJECTS } from '../data/tests/constants';
 import { renderWithRouter } from '../../../utils/tests';
 import { NO_OPTIONS_FOUND } from '../data/constants';
 
-const TITLE = 'Free / All';
 const propsForNoItems = {
   items: [],
-  title: TITLE,
+  title: FREE_ALL_TITLE,
   showAllCatalogs: false,
   setShowAllCatalogs: () => {},
 };
@@ -39,11 +39,11 @@ describe('<FacetListFreeAll />', () => {
     renderWithRouter(<FacetListFreeAll {...propsForNoItems} />);
 
     // assert facet title exists
-    expect(screen.queryByText(TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(FREE_ALL_TITLE)).toBeInTheDocument();
 
     // assert there are no options
     await act(async () => {
-      fireEvent.click(screen.queryByText(TITLE));
+      fireEvent.click(screen.queryByText(FREE_ALL_TITLE));
     });
     expect(screen.queryByText(NO_OPTIONS_FOUND)).toBeInTheDocument();
   });
@@ -56,7 +56,7 @@ describe('<FacetListFreeAll />', () => {
 
     // assert the refinements appear with appropriate counts
     await act(async () => {
-      fireEvent.click(screen.queryByText(TITLE));
+      fireEvent.click(screen.queryByText(FREE_ALL_TITLE));
     });
     expect(screen.queryByText(FREE_LABEL)).toBeInTheDocument();
     expect(screen.queryByText(NOT_FREE_LABEL)).toBeInTheDocument();
@@ -67,7 +67,7 @@ describe('<FacetListFreeAll />', () => {
 
     // assert the "no options" message does not show
     await act(async () => {
-      fireEvent.click(screen.queryByText(TITLE));
+      fireEvent.click(screen.queryByText(FREE_ALL_TITLE));
     });
     expect(screen.queryByText(NO_OPTIONS_FOUND)).not.toBeInTheDocument();
 
@@ -88,7 +88,7 @@ describe('<FacetListFreeAll />', () => {
 
     // assert the refinements appear
     await act(async () => {
-      fireEvent.click(screen.queryByText(TITLE));
+      fireEvent.click(screen.queryByText(FREE_ALL_TITLE));
     });
     expect(screen.queryByText(FREE_LABEL)).toBeInTheDocument();
 
@@ -108,7 +108,7 @@ describe('<FacetListFreeAll />', () => {
 
     // assert the refinements appear
     await act(async () => {
-      fireEvent.click(screen.queryByText(TITLE));
+      fireEvent.click(screen.queryByText(FREE_ALL_TITLE));
     });
     // click a refinement option
     await act(async () => {

--- a/src/components/search/tests/FacetListFreeAll.test.jsx
+++ b/src/components/search/tests/FacetListFreeAll.test.jsx
@@ -3,7 +3,7 @@ import { act, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import FacetListFreeAll from '../FacetListFreeAll';
-
+import { FACET_ATTRIBUTES, SUBJECTS } from '../data/tests/constants';
 import { renderWithRouter } from '../../../utils/tests';
 import { NO_OPTIONS_FOUND } from '../data/constants';
 
@@ -28,6 +28,10 @@ const propsWithItems = {
     value: false,
   },
   ],
+  refinementsFromQueryParams: {
+    [FACET_ATTRIBUTES.SUBJECTS]: [SUBJECTS.COMMUNICATION],
+    page: 3,
+  },
 };
 
 describe('<FacetListFreeAll />', () => {
@@ -95,5 +99,23 @@ describe('<FacetListFreeAll />', () => {
 
     // assert the spy was called with the correct value
     expect(spy).toHaveBeenCalledWith(!propsWithItems.items[1].value);
+  });
+  test('clears pagination when clicking on a refinement', async () => {
+    const { history } = renderWithRouter(<FacetListFreeAll
+      {...propsWithItems}
+    />,
+    { route: '/search?subjects=Communication&page=3' });
+
+    // assert the refinements appear
+    await act(async () => {
+      fireEvent.click(screen.queryByText(TITLE));
+    });
+    // click a refinement option
+    await act(async () => {
+      fireEvent.click(screen.queryByText(NOT_FREE_LABEL));
+    });
+
+    // assert page was deleted and partners were not
+    expect(history.location.search).toEqual('?subjects=Communication');
   });
 });

--- a/src/components/search/tests/FacetListRefinement.test.jsx
+++ b/src/components/search/tests/FacetListRefinement.test.jsx
@@ -111,4 +111,23 @@ describe('<FacetListRefinement />', () => {
     // assert the clicked refinement was added to the url
     expect(history.location.search).toEqual('?subjects=Communication');
   });
+
+  test('clears pagination when clicking on a refinement', async () => {
+    const { history } = renderWithRouter(<FacetListBase
+      {...propsForActiveRefinements}
+      refinementsFromQueryParams={{ ...propsForActiveRefinements.refinementsFromQueryParams, page: 3 }}
+    />, { route: '/search?page=3' });
+
+    // assert the refinements appear
+    await act(async () => {
+      fireEvent.click(screen.queryByText(FACET_ATTRIBUTES.SUBJECTS));
+    });
+    // click a refinement option
+    await act(async () => {
+      fireEvent.click(screen.queryByText(SUBJECTS.COMMUNICATION));
+    });
+
+    // assert page was deleted and partners were not
+    expect(history.location.search).toEqual('?subjects=Communication');
+  });
 });


### PR DESCRIPTION
Adding the pagination reset makes the two filter components similar enough that I kiiiind of want to refactor into one component again, but since this ticket is way overdue, I figure we can do that the next time we touch the filters.

This also makes small changes to the filter labels and fixes the subscription with codes query which was not working as expected on stage.