### PR TITLE
Creates new github action to replace travis file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: node_js CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - run: npm ci
+    - run: npm run lint
+    - run: npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js: 12
-script:
-  - npm run lint
-  - npm run test


### PR DESCRIPTION
This moves us off of travis and uses github actions instead. You can see the check on this PR below.

SRE will need to remove travis from this repo entirely before this can be merged

Note: this doesn't address the numerous `console.error` that are **not** failing the build but probably should be, but this is the same as it was for travis.