### PR TITLE
bug: ENT-3715 enroll button cta bug fix for codes

### DIFF
--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -1,6 +1,4 @@
-import {
-  useEffect, useState, useMemo, useContext,
-} from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import qs from 'query-string';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
@@ -14,9 +12,6 @@ import {
   numberWithPrecision,
   findOfferForCourse,
   hasLicenseSubsidy,
-  hasCourseStarted,
-  findUserEnrollmentForCourse,
-  findHighestLevelSeatSku,
 } from './utils';
 import {
   COURSE_PACING_MAP,
@@ -25,10 +20,6 @@ import {
   ENROLLMENT_FAILED_QUERY_PARAM,
 } from './constants';
 import { features } from '../../../config';
-
-import { UserSubsidyContext } from '../../enterprise-user-subsidy';
-
-import { CourseContext } from '../CourseContextProvider';
 
 export function useAllCourseData({ courseKey, enterpriseConfig, courseRunKey }) {
   const [courseData, setCourseData] = useState();
@@ -261,82 +252,5 @@ export function useCourseEnrollmentUrl({
     [baseEnrollmentOptions, subscriptionLicense, enterpriseConfig, offers, sku],
   );
 
-  return enrollmentUrl;
-}
-
-/**
- * A hook to obtain data, for use with the enroll button for example. It answers these questions
- * by reading the CourseContext context:
- *
- * 1. isUserEnrolled
- * 2. isCourseStarted
- * 3. isEnrollable
- *
- * These three answers can help with the main flow of EnrollButton.
- */
-export function useCourseData() {
-  const { state: courseData } = useContext(CourseContext);
-  const { activeCourseRun, userEnrollments, userEntitlements } = courseData;
-  const { start, key, isEnrollable } = activeCourseRun;
-
-  const isCourseStarted = useMemo(
-    () => hasCourseStarted(start),
-    [start],
-  );
-
-  const userEnrollment = useMemo(
-    () => findUserEnrollmentForCourse({ userEnrollments, key }),
-    [userEnrollments, key],
-  );
-
-  return {
-    isUserEnrolled: !!userEnrollment,
-    isCourseStarted,
-    isEnrollable,
-    activeCourseRun,
-    userEntitlements,
-  };
-}
-
-/**
- * Get subscriptions, offers info about the user.
- */
-export function useSubsidies() {
-  const { subscriptionLicense, offers } = useContext(UserSubsidyContext);
-  return {
-    subscriptionLicense,
-    offers,
-  };
-}
-
-/**
- * @param {object} args arguments.
- * @param {object} args.enterpriseConfig enterprise configuration.
- * @param {object} args.location location for react router
- */
-export function useEnrollmentUrl({ enterpriseConfig, location }) {
-  const { state: courseData } = useContext(CourseContext);
-  const { subscriptionLicense, offers } = useSubsidies();
-  const {
-    activeCourseRun: { seats, key },
-    userSubsidy,
-    catalog: { catalogList },
-  } = courseData;
-
-  const sku = useMemo(
-    () => findHighestLevelSeatSku(seats),
-    [seats],
-  );
-
-  const enrollmentUrl = useCourseEnrollmentUrl({
-    catalogList,
-    enterpriseConfig,
-    key,
-    location,
-    offers,
-    sku,
-    subscriptionLicense,
-    userSubsidy,
-  });
   return enrollmentUrl;
 }


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-3715

Fixes two issues:

1. when subscription is not valid for course (as checked by userSubsidy), modal was not shown to warn usre before taking to basket page. Now it does.

2. when subscription is not valid and user tries to enroll with codes (whether or not they have any left), the feature switch did not disable the Enroll button, now it does

The bug fix is entirely in EnrollButton.jsx. The hooks file change is meant for upcoming refactor and has no impact right now but will be used once refactoring starts.

## Testing notes
Tested with two courses:

A: Course 1 : is in subscription catalog: got no modal and got taken to data consent page
B: Course 2: is not in subscription catalog but is in a non-subscription catalog: got a modal and got taken to basket page ecommerce

Since I did not change logic around the modal and what to show etc I did not feel necessary to test for the case of codes present. But if reviewers feel otherwise I can try those.


Refactoring is. the plan next, I can either do that as new commits here, or in a new PR


