### PR TITLE
fix: request only active enrollments from the enterprise_learner_port…

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/data/service.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/service.js
@@ -6,6 +6,7 @@ import { getConfig } from '@edx/frontend-platform/config';
 export const fetchEnterpriseCourseEnrollments = (uuid) => {
   const queryParams = {
     enterprise_id: uuid,
+    is_active: true,
   };
   const config = getConfig();
   const url = `${config.LMS_BASE_URL}/enterprise_learner_portal/api/v1/enterprise_course_enrollments/?${qs.stringify(queryParams)}`;

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/service.test.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/service.test.js
@@ -14,7 +14,7 @@ axios.get = jest.fn();
 
 describe('course enrollments service', () => {
   it('fetches enterprise enrollments', () => {
-    const url = 'http://localhost:18000/enterprise_learner_portal/api/v1/enterprise_course_enrollments/?enterprise_id=test-enterprise-id';
+    const url = 'http://localhost:18000/enterprise_learner_portal/api/v1/enterprise_course_enrollments/?enterprise_id=test-enterprise-id&is_active=true';
     fetchEnterpriseCourseEnrollments('test-enterprise-id');
     expect(axios.get).toBeCalledWith(url);
   });


### PR DESCRIPTION
…al/course-enrollments endpoint

https://openedx.atlassian.net/browse/ENT-3764