### PR TITLE
feat: use new license manager endpoint to fetch license data

### DIFF
--- a/src/components/enterprise-user-subsidy/UserSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidy.jsx
@@ -11,7 +11,7 @@ export const UserSubsidyContext = createContext();
 
 const UserSubsidy = ({ children }) => {
   const { subscriptionPlan, enterpriseConfig } = useContext(AppContext);
-  const [subscriptionLicense, isLoadingLicense] = useSubscriptionLicenseForUser(subscriptionPlan);
+  const [subscriptionLicense, isLoadingLicense] = useSubscriptionLicenseForUser(enterpriseConfig.uuid);
   const [offers, isLoadingOffers] = useOffers(enterpriseConfig.uuid);
 
   const isLoadingSubsidies = useMemo(

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -24,11 +24,11 @@ export function useSubscriptionLicenseForUser(enterpriseId) {
         const revoked = results.filter(result => result.status === LICENSE_STATUS.REVOKED);
 
         if (activated.length) {
-          setLicense(activated.pop());
+          setLicense(activated.shift());
         } else if (assigned.length) {
-          setLicense(assigned.pop());
+          setLicense(assigned.shift());
         } else if (revoked.length) {
-          setLicense(revoked.pop());
+          setLicense(revoked.shift());
         } else {
           setLicense(null);
         }

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -16,49 +16,37 @@ import {
 } from '../../../utils/common';
 import { features } from '../../../config';
 
-export function useSubscriptionLicenseForUser(subscriptionPlan) {
+export function useSubscriptionLicenseForUser(enterpriseId) {
   const [license, setLicense] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (isDefinedAndNull(subscriptionPlan)) {
-      setIsLoading(false);
-      return;
-    }
+    fetchSubscriptionLicensesForUser(enterpriseId)
+      .then((response) => {
+        const { results } = camelCaseObject(response.data);
+        const activated = results.filter(result => result.status === LICENSE_STATUS.ACTIVATED);
+        const assigned = results.filter(result => result.status === LICENSE_STATUS.ASSIGNED);
+        const revoked = results.filter(result => result.status === LICENSE_STATUS.REVOKED);
 
-    if (isDefinedAndNotNull(subscriptionPlan)) {
-      if (!hasValidStartExpirationDates(subscriptionPlan)) {
-        setIsLoading(false);
-        return;
-      }
-
-      fetchSubscriptionLicensesForUser(subscriptionPlan.uuid)
-        .then((response) => {
-          const { results } = camelCaseObject(response.data);
-          const activated = results.filter(result => result.status === LICENSE_STATUS.ACTIVATED);
-          const assigned = results.filter(result => result.status === LICENSE_STATUS.ASSIGNED);
-          const revoked = results.filter(result => result.status === LICENSE_STATUS.REVOKED);
-
-          if (activated.length) {
-            setLicense(activated.pop());
-          } else if (assigned.length) {
-            setLicense(assigned.pop());
-          } else if (revoked.length) {
-            setLicense(revoked.pop());
-          } else {
-            setLicense(null);
-          }
-        })
-        .catch((error) => {
-          logError(new Error(error));
+        if (activated.length) {
+          setLicense(activated.pop());
+        } else if (assigned.length) {
+          setLicense(assigned.pop());
+        } else if (revoked.length) {
+          setLicense(revoked.pop());
+        } else {
           setLicense(null);
-        })
-        .finally(() => {
-          setIsLoading(false);
-        });
-    }
-  }, [subscriptionPlan]);
-
+        }
+      })
+      .catch((error) => {
+        logError(new Error(error));
+        setLicense(null);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [enterpriseId]);
+  console.log(license);
   return [license, isLoading];
 }
 

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -9,11 +9,6 @@ import offersReducer, { initialOfferState } from '../offers/data/reducer';
 
 import { LICENSE_STATUS } from './constants';
 import { fetchSubscriptionLicensesForUser } from './service';
-import {
-  hasValidStartExpirationDates,
-  isDefinedAndNotNull,
-  isDefinedAndNull,
-} from '../../../utils/common';
 import { features } from '../../../config';
 
 export function useSubscriptionLicenseForUser(enterpriseId) {
@@ -46,7 +41,7 @@ export function useSubscriptionLicenseForUser(enterpriseId) {
         setIsLoading(false);
       });
   }, [enterpriseId]);
-  console.log(license);
+
   return [license, isLoading];
 }
 

--- a/src/components/enterprise-user-subsidy/data/service.js
+++ b/src/components/enterprise-user-subsidy/data/service.js
@@ -3,7 +3,7 @@ import { getConfig } from '@edx/frontend-platform/config';
 
 export function fetchSubscriptionLicensesForUser(enterpriseUuid) {
   const config = getConfig();
-  const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-licenses?enterprise_customer_uuid=${enterpriseUuid}`;
+  const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-licenses/?enterprise_customer_uuid=${enterpriseUuid}`;
   const httpClient = getAuthenticatedHttpClient({
     useCache: config.USE_API_CACHE,
   });

--- a/src/components/enterprise-user-subsidy/data/service.js
+++ b/src/components/enterprise-user-subsidy/data/service.js
@@ -1,13 +1,9 @@
-import qs from 'query-string';
-import { getAuthenticatedUser, getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
-export function fetchSubscriptionLicensesForUser(subscriptionUuid) {
+export function fetchSubscriptionLicensesForUser(enterpriseUuid) {
   const config = getConfig();
-  const user = getAuthenticatedUser();
-  const { email } = user;
-  const queryParams = { search: email };
-  const url = `${config.LICENSE_MANAGER_URL}/api/v1/subscriptions/${subscriptionUuid}/license/?${qs.stringify(queryParams)}`;
+  const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-licenses?enterprise_customer_uuid=${enterpriseUuid}`;
   const httpClient = getAuthenticatedHttpClient({
     useCache: config.USE_API_CACHE,
   });

--- a/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
@@ -20,12 +20,16 @@ jest.mock('../../../config', () => ({
 const TEST_SUBSCRIPTION_UUID = 'test-subscription-uuid';
 const TEST_LICENSE_UUID = 'test-license-uuid';
 const TEST_ENTERPRISE_SLUG = 'test-enterprise-slug';
+const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
 
 // eslint-disable-next-line react/prop-types
 const UserSubsidyWithAppContext = ({ contextValue = {}, children }) => (
   <AppContext.Provider
     value={{
-      enterpriseConfig: { slug: TEST_ENTERPRISE_SLUG },
+      enterpriseConfig: {
+        slug: TEST_ENTERPRISE_SLUG,
+        uuid: TEST_ENTERPRISE_UUID,
+      },
       ...contextValue,
     }}
   >
@@ -59,13 +63,12 @@ describe('UserSubsidy', () => {
     beforeEach(() => {
       const promise = Promise.resolve({
         data: {
-          data: {
-            count: 0,
-            results: [],
-          },
+          count: 0,
+          results: [],
         },
       });
       fetchOffers.mockResolvedValueOnce(promise);
+      fetchSubscriptionLicensesForUser.mockResolvedValueOnce(promise);
     });
 
     afterEach(() => {
@@ -133,11 +136,12 @@ describe('UserSubsidy', () => {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
-      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_SUBSCRIPTION_UUID);
+      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       await waitFor(() => {
         expect(screen.queryByText('Has access: false')).toBeInTheDocument();
       });
     });
+
     test('with license, shows correct portal access', async () => {
       const promise = Promise.resolve({
         data: {
@@ -157,11 +161,12 @@ describe('UserSubsidy', () => {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
-      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_SUBSCRIPTION_UUID);
+      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       await waitFor(() => {
         expect(screen.queryByText('Has access: true')).toBeInTheDocument();
       });
     });
+
     test('provides license data', async () => {
       const promise = Promise.resolve({
         data: {
@@ -181,11 +186,12 @@ describe('UserSubsidy', () => {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
-      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_SUBSCRIPTION_UUID);
+      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       await waitFor(() => {
         expect(screen.queryByText(`License status: ${LICENSE_STATUS.ACTIVATED}`)).toBeInTheDocument();
       });
     });
+
     test('provides offers data', async () => {
       const promise = Promise.resolve({
         data: {
@@ -205,7 +211,7 @@ describe('UserSubsidy', () => {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
-      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_SUBSCRIPTION_UUID);
+      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledTimes(1);
       await waitFor(() => {
         expect(screen.queryByText('Offers count: 0')).toBeInTheDocument();
@@ -255,7 +261,7 @@ describe('UserSubsidy', () => {
       expect(screen.getByText(LOADING_SCREEN_READER_TEXT)).toBeInTheDocument();
 
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
-      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_SUBSCRIPTION_UUID);
+      expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
 
       await waitFor(() => {
         expect(screen.getByTestId('did-i-render')).toBeInTheDocument();


### PR DESCRIPTION
Frontend ticket to leverage new license-manager endpoint for fetching Learner License data created in https://github.com/edx/frontend-app-learner-portal-enterprise/pull/176