### PR TITLE
fix: remove frontend caching on learner-licenses endpoint

### DIFF
--- a/src/components/enterprise-user-subsidy/data/service.js
+++ b/src/components/enterprise-user-subsidy/data/service.js
@@ -4,8 +4,5 @@ import { getConfig } from '@edx/frontend-platform/config';
 export function fetchSubscriptionLicensesForUser(enterpriseUuid) {
   const config = getConfig();
   const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-licenses/?enterprise_customer_uuid=${enterpriseUuid}`;
-  const httpClient = getAuthenticatedHttpClient({
-    useCache: config.USE_API_CACHE,
-  });
-  return httpClient.get(url);
+  return getAuthenticatedHttpClient().get(url);
 }


### PR DESCRIPTION
This PR removes the frontend caching on the `learner-licenses` API request.

Previously, if a learner's license is pending on initial page visit, followed by the learner activating their license via the activation email, we had stale data in the client's cache about the user's pending license when we really want to fetch the latest license data instead.