### PR TITLE
Show offer discounted price if subscription does not apply, ENT-3632

### DIFF
--- a/src/components/course/Course.jsx
+++ b/src/components/course/Course.jsx
@@ -41,7 +41,7 @@ export default function Course() {
     () => {
       if (courseData) {
         const {
-          courseDetails, userEnrollments, userEntitlements, userSubsidy, catalog,
+          courseDetails, userEnrollments, userEntitlements, userSubsidyApplicableToCourse, catalog,
         } = courseData;
         return {
           course: courseDetails,
@@ -49,7 +49,7 @@ export default function Course() {
           availableCourseRuns: getAvailableCourseRuns(courseDetails),
           userEnrollments,
           userEntitlements,
-          userSubsidy,
+          userSubsidyApplicableToCourse,
           catalog,
         };
       }

--- a/src/components/course/CourseContextProvider.jsx
+++ b/src/components/course/CourseContextProvider.jsx
@@ -33,7 +33,7 @@ CourseContextProvider.propTypes = {
     activeCourseRun: PropTypes.shape({}).isRequired,
     userEnrollments: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     userEntitlements: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-    userSubsidyApplicableToCourse: PropTypes.shape({}).isRequired,
+    userSubsidyApplicableToCourse: PropTypes.shape({}),
     catalog: PropTypes.shape({}).isRequired,
   }).isRequired,
 };

--- a/src/components/course/CourseContextProvider.jsx
+++ b/src/components/course/CourseContextProvider.jsx
@@ -33,7 +33,7 @@ CourseContextProvider.propTypes = {
     activeCourseRun: PropTypes.shape({}).isRequired,
     userEnrollments: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     userEntitlements: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-    userSubsidy: PropTypes.shape({}).isRequired,
+    userSubsidyApplicableToCourse: PropTypes.shape({}).isRequired,
     catalog: PropTypes.shape({}).isRequired,
   }).isRequired,
 };

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -40,9 +40,7 @@ const CourseSidebarPrice = () => {
       <>
         {showOrigPrice && (
           <div className="mb-2">
-            <del>
-              <span className="sr-only">Priced reduced from:</span>${originalPriceDisplay} {currency}
-            </del>
+            {crossedOutOriginalPrice}
           </div>
         )}
         <span>{INCLUDED_IN_SUBSCRIPTION_MESSAGE}</span>
@@ -61,7 +59,7 @@ const CourseSidebarPrice = () => {
   return (
     <>
       <div className={classNames({ 'mb-2': coursePrice.discounted > 0 || showOrigPrice })}>
-        {/* discounted > 0 means partial discount, next block is full discount */}
+        {/* discounted > 0 means partial discount */}
         {coursePrice.discounted > 0 && (
           <>
             <span className="sr-only">Discounted price:</span>${discountedPriceDisplay}

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -10,6 +10,8 @@ import {
   useCoursePriceForUserSubsidy,
 } from './data/hooks';
 
+export const INCLUDED_IN_SUBSCRIPTION_MESSAGE = 'Included in your subscription';
+
 const CourseSidebarPrice = () => {
   const { state: courseData } = useContext(CourseContext);
   const { activeCourseRun, userSubsidy, catalog: { catalogList } } = courseData;
@@ -31,7 +33,7 @@ const CourseSidebarPrice = () => {
             <del>${numberWithPrecision(coursePrice.list)} {currency}</del>
           </div>
         )}
-        <span>Included in your subscription</span>
+        <span>{INCLUDED_IN_SUBSCRIPTION_MESSAGE}</span>
       </>
     );
   }

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -25,12 +25,23 @@ const CourseSidebarPrice = () => {
     return <Skeleton height={24} />;
   }
 
+  const originalPriceDisplay = numberWithPrecision(coursePrice.list);
+  const showOrigPrice = !enterpriseConfig.hideCourseOriginalPrice;
+  const crossedOutOriginalPrice = (
+    <>
+      {' '}
+      <del>${originalPriceDisplay} {currency}</del>
+      {' '}
+    </>
+  );
+
+  // Case 1: License subsidy found
   if (hasLicenseSubsidy(userSubsidy)) {
     return (
       <>
-        {!enterpriseConfig.hideCourseOriginalPrice && (
+        {showOrigPrice && (
           <div className="mb-2">
-            <del>${numberWithPrecision(coursePrice.list)} {currency}</del>
+            <del>${originalPriceDisplay} {currency}</del>
           </div>
         )}
         <span>{INCLUDED_IN_SUBSCRIPTION_MESSAGE}</span>
@@ -38,28 +49,25 @@ const CourseSidebarPrice = () => {
     );
   }
 
+  // Case 2: No subsidies found
   const hasDiscountedPrice = coursePrice.discounted < coursePrice.list;
   if (!hasDiscountedPrice) {
-    return <span>${numberWithPrecision(coursePrice.list)} {currency}</span>;
+    return <>{showOrigPrice && <span>${originalPriceDisplay} {currency}</span>}</>;
   }
 
+  // Case 3: offer subsidy found
+  const discountedPriceDisplay = `${numberWithPrecision(coursePrice.discounted)} ${currency}`;
   return (
     <>
       <div className="mb-2">
         {coursePrice.discounted > 0 ? (
           <>
-            ${numberWithPrecision(coursePrice.discounted)}
-            {!enterpriseConfig?.hideCourseOriginalPrice && (
-              <>
-                {' '}
-                <del>${numberWithPrecision(coursePrice.list)}</del>
-              </>
-            )}
-            {' '}
+            ${discountedPriceDisplay}
+            {showOrigPrice && crossedOutOriginalPrice}
           </>
         ) : (
           <>
-            ${numberWithPrecision(coursePrice.discounted)} {currency}
+            {showOrigPrice && crossedOutOriginalPrice}
           </>
         )}
       </div>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -30,11 +30,9 @@ const CourseSidebarPrice = () => {
   const originalPriceDisplay = numberWithPrecision(coursePrice.list);
   const showOrigPrice = !enterpriseConfig.hideCourseOriginalPrice;
   const crossedOutOriginalPrice = (
-    <>
-      {' '}
-      <del><span className="sr-only">Priced reduced from:</span>${originalPriceDisplay} {currency}</del>
-      {' '}
-    </>
+    <del>
+      <span className="sr-only">Priced reduced from:</span>${originalPriceDisplay} {currency}
+    </del>
   );
 
   // Case 1: License subsidy found
@@ -68,11 +66,11 @@ const CourseSidebarPrice = () => {
         {coursePrice.discounted > 0 ? (
           <>
             <span className="sr-only">Discounted price:</span>${discountedPriceDisplay}
-            {showOrigPrice && crossedOutOriginalPrice}
+            {showOrigPrice && <>{' '} {crossedOutOriginalPrice}{' '}</>}
           </>
         ) : (
           <>
-            {showOrigPrice && crossedOutOriginalPrice}
+            {showOrigPrice && <>{' '} {crossedOutOriginalPrice}{' '}</>}
           </>
         )}
       </div>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -11,11 +11,13 @@ import {
 } from './data/hooks';
 
 const CourseSidebarPrice = () => {
-  const { state } = useContext(CourseContext);
-  const { activeCourseRun, userSubsidy, catalog: { catalogList } } = state;
+  const { state: courseData } = useContext(CourseContext);
+  const { activeCourseRun, userSubsidy, catalog: { catalogList } } = courseData;
   const { enterpriseConfig } = useContext(AppContext);
   const { offers: { offers } } = useContext(UserSubsidyContext);
-  const [coursePrice, currency] = useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy, offers, catalogList);
+  const [coursePrice, currency] = useCoursePriceForUserSubsidy({
+    activeCourseRun, userSubsidy, offers, catalogList,
+  });
 
   if (!coursePrice) {
     return <Skeleton height={24} />;

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -30,7 +30,7 @@ const CourseSidebarPrice = () => {
   const crossedOutOriginalPrice = (
     <>
       {' '}
-      <del>${originalPriceDisplay} {currency}</del>
+      <del><span className="sr-only">Priced reduced from:</span>${originalPriceDisplay} {currency}</del>
       {' '}
     </>
   );
@@ -41,7 +41,9 @@ const CourseSidebarPrice = () => {
       <>
         {showOrigPrice && (
           <div className="mb-2">
-            <del>${originalPriceDisplay} {currency}</del>
+            <del>
+              <span className="sr-only">Priced reduced from:</span>${originalPriceDisplay} {currency}
+            </del>
           </div>
         )}
         <span>{INCLUDED_IN_SUBSCRIPTION_MESSAGE}</span>
@@ -62,7 +64,7 @@ const CourseSidebarPrice = () => {
       <div className="mb-2">
         {coursePrice.discounted > 0 ? (
           <>
-            ${discountedPriceDisplay}
+            <span className="sr-only">Discounted price:</span>${discountedPriceDisplay}
             {showOrigPrice && crossedOutOriginalPrice}
           </>
         ) : (

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react';
 import Skeleton from 'react-loading-skeleton';
+import classNames from 'classnames';
+
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { CourseContext } from './CourseContextProvider';
@@ -61,7 +63,7 @@ const CourseSidebarPrice = () => {
   const discountedPriceDisplay = `${numberWithPrecision(coursePrice.discounted)} ${currency}`;
   return (
     <>
-      <div className="mb-2">
+      <div className={classNames({ 'mb-2': coursePrice.discounted > 0 || showOrigPrice })}>
         {/* discounted > 0 means partial discount, next block is full discount */}
         {coursePrice.discounted > 0 ? (
           <>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -60,12 +60,12 @@ const CourseSidebarPrice = () => {
     <>
       <div className={classNames({ 'mb-2': coursePrice.discounted > 0 || showOrigPrice })}>
         {/* discounted > 0 means partial discount */}
+        {showOrigPrice && <>{crossedOutOriginalPrice}{' '}</>}
         {coursePrice.discounted > 0 && (
           <>
             <span className="sr-only">Discounted price:</span>${discountedPriceDisplay}
           </>
         )}
-        {showOrigPrice && <>{' '} {crossedOutOriginalPrice}{' '}</>}
       </div>
       <span>Sponsored by {enterpriseConfig.name}</span>
     </>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { CourseContext } from './CourseContextProvider';
-import { UserSubsidyContext } from '../enterprise-user-subsidy/UserSubsidy';
 import { numberWithPrecision, hasLicenseSubsidy } from './data/utils';
 
 import {
@@ -16,11 +15,13 @@ export const INCLUDED_IN_SUBSCRIPTION_MESSAGE = 'Included in your subscription';
 
 const CourseSidebarPrice = () => {
   const { state: courseData } = useContext(CourseContext);
-  const { activeCourseRun, userSubsidy, catalog: { catalogList } } = courseData;
+  const { activeCourseRun, userSubsidyApplicableToCourse } = courseData;
   const { enterpriseConfig } = useContext(AppContext);
-  const { offers: { offers } } = useContext(UserSubsidyContext);
+
+  // TODO: add code to produce correct userSubsidy based on offers/catalogs
+
   const [coursePrice, currency] = useCoursePriceForUserSubsidy({
-    activeCourseRun, userSubsidy, offers, catalogList,
+    activeCourseRun, userSubsidyApplicableToCourse,
   });
 
   if (!coursePrice) {
@@ -36,7 +37,7 @@ const CourseSidebarPrice = () => {
   );
 
   // Case 1: License subsidy found
-  if (hasLicenseSubsidy(userSubsidy)) {
+  if (hasLicenseSubsidy(userSubsidyApplicableToCourse)) {
     return (
       <>
         {showOrigPrice && (
@@ -63,16 +64,12 @@ const CourseSidebarPrice = () => {
     <>
       <div className={classNames({ 'mb-2': coursePrice.discounted > 0 || showOrigPrice })}>
         {/* discounted > 0 means partial discount, next block is full discount */}
-        {coursePrice.discounted > 0 ? (
+        {coursePrice.discounted > 0 && (
           <>
             <span className="sr-only">Discounted price:</span>${discountedPriceDisplay}
-            {showOrigPrice && <>{' '} {crossedOutOriginalPrice}{' '}</>}
-          </>
-        ) : (
-          <>
-            {showOrigPrice && <>{' '} {crossedOutOriginalPrice}{' '}</>}
           </>
         )}
+        {showOrigPrice && <>{' '} {crossedOutOriginalPrice}{' '}</>}
       </div>
       <span>Sponsored by {enterpriseConfig.name}</span>
     </>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -18,8 +18,6 @@ const CourseSidebarPrice = () => {
   const { activeCourseRun, userSubsidyApplicableToCourse } = courseData;
   const { enterpriseConfig } = useContext(AppContext);
 
-  // TODO: add code to produce correct userSubsidy based on offers/catalogs
-
   const [coursePrice, currency] = useCoursePriceForUserSubsidy({
     activeCourseRun, userSubsidyApplicableToCourse,
   });

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -54,7 +54,7 @@ const CourseSidebarPrice = () => {
   // Case 2: No subsidies found
   const hasDiscountedPrice = coursePrice.discounted < coursePrice.list;
   if (!hasDiscountedPrice) {
-    return <>{showOrigPrice && <span>${originalPriceDisplay} {currency}</span>}</>;
+    return <span>${originalPriceDisplay} {currency}</span>;
   }
 
   // Case 3: offer subsidy found
@@ -62,6 +62,7 @@ const CourseSidebarPrice = () => {
   return (
     <>
       <div className="mb-2">
+        {/* discounted > 0 means partial discount, next block is full discount */}
         {coursePrice.discounted > 0 ? (
           <>
             <span className="sr-only">Discounted price:</span>${discountedPriceDisplay}

--- a/src/components/course/EnrollButton.jsx
+++ b/src/components/course/EnrollButton.jsx
@@ -54,7 +54,7 @@ export default function EnrollButton() {
     activeCourseRun,
     userEnrollments,
     userEntitlements,
-    userSubsidy,
+    userSubsidyApplicableToCourse,
     catalog: { catalogList },
   } = courseData;
   const {
@@ -87,7 +87,7 @@ export default function EnrollButton() {
     offers,
     sku,
     subscriptionLicense,
-    userSubsidy,
+    userSubsidyApplicableToCourse,
   });
 
   const EnrollLabel = props => (
@@ -123,7 +123,7 @@ export default function EnrollButton() {
   if (!userEnrollment && isEnrollable) {
     // enroll with a subscription license
     if (enrollmentUrl && subscriptionLicense) {
-      if (userSubsidy) {
+      if (userSubsidyApplicableToCourse) {
         return (
           <EnrollButtonCta
             as="a"

--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -11,6 +11,7 @@ export const SUBSIDY_DISCOUNT_TYPE_MAP = {
 };
 
 export const LICENSE_SUBSIDY_TYPE = 'license';
+export const OFFER_SUBSIDY_TYPE = 'offer';
 
 export const PROMISE_FULFILLED = 'fulfilled';
 

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -231,7 +231,6 @@ useCoursePriceForUserSubsidy.propTypes = {
     discountValue: PropTypes.number.isRequired,
     expirationDate: PropTypes.string.isRequired,
     startDate: PropTypes.string.isRequired,
-    status: PropTypes.string.isRequired,
     subsidyId: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -215,7 +215,7 @@ const useCoursePriceForUserSubsidy = ({
         };
       }
 
-      // Case 2: No subsidy, no offers for course
+      // Case 2: No subsidy available for course
       return onlyListPrice;
     },
     [activeCourseRun, userSubsidyApplicableToCourse],

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -221,7 +221,7 @@ export function useCoursePriceForUserSubsidy({
       }
       return onlyListPrice;
     },
-    [activeCourseRun, userSubsidy, offers],
+    [activeCourseRun, userSubsidy, offers, catalogList],
   );
 
   return [coursePrice, currency];

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -1,10 +1,14 @@
-import { useEffect, useState, useMemo } from 'react';
+import {
+  useEffect, useState, useMemo, useContext,
+} from 'react';
 import qs from 'query-string';
 import PropTypes from 'prop-types';
 
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { getConfig } from '@edx/frontend-platform/config';
+
+import { UserSubsidyContext } from '../../enterprise-user-subsidy/UserSubsidy';
 
 import { isDefinedAndNotNull } from '../../../utils/common';
 import CourseService from './service';
@@ -26,6 +30,10 @@ export function useAllCourseData({ courseKey, enterpriseConfig, courseRunKey }) 
   const [courseData, setCourseData] = useState();
   const [fetchError, setFetchError] = useState();
 
+  // todo: this could get refactored, but since we already fetch offers
+  // we simply pass offers along to the `fetchAllCourseData` call to 'fetch' it back
+  const { offers: { offers } } = useContext(UserSubsidyContext);
+
   useEffect(() => {
     const fetchData = async () => {
       if (courseKey && enterpriseConfig) {
@@ -35,7 +43,7 @@ export function useAllCourseData({ courseKey, enterpriseConfig, courseRunKey }) 
           courseRunKey,
         });
         try {
-          const data = await courseService.fetchAllCourseData();
+          const data = await courseService.fetchAllCourseData({ offers });
           setCourseData(data);
         } catch (error) {
           logError(error);

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -156,7 +156,9 @@ export function useCoursePacingType(courseRun) {
   return [pacingType, pacingTypeContent];
 }
 
-export function useCoursePriceForUserSubsidy(activeCourseRun, userSubsidy, offers, catalogList) {
+export function useCoursePriceForUserSubsidy({
+  activeCourseRun, userSubsidy, offers, catalogList,
+}) {
   const currency = CURRENCY_USD;
 
   const coursePrice = useMemo(

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -91,11 +91,11 @@ export default class CourseService {
   }
 
   async fetchEnterpriseUserSubsidy({ offers, catalogList }) {
-    // TODO: this will likely be expanded to support codes/offers, by appending to
-    // the below array to provide a function that makes the relevant API call(s)
-    // for the specified subsidy type.
+    // TODO: the license subsidy is fetched from backend, but the offer subsidy currently is being
+    //       used from the passed in arguments (fetched already by UserSubsidy.jsx).
+    //       Need to reconcile api to make it consistent for offers vs subsidies
     //
-    // note: these API calls should be ordered by priority. Example: if a user has
+    // Note: these API calls should be ordered by priority. Example: if a user has
     // a license subsidy, we use that as the user's final subsidy. if not, we check
     // if the user has a code subsidy, and so on.
     const SUBSIDY_TYPES = [

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -92,8 +92,8 @@ export default class CourseService {
 
   async fetchEnterpriseUserSubsidy({ offers, catalogList }) {
     // TODO: the license subsidy is fetched from backend, but the offer subsidy currently is being
-    //       used from the passed in arguments (fetched already by UserSubsidy.jsx).
-    //       Need to reconcile api to make it consistent for offers vs subsidies
+    //   used from the passed in arguments (fetched already by UserSubsidy.jsx).
+    //  Need to reconcile api to make it consistent for all subsidy types: offers, subscriptions
     //
     // Note: these API calls should be ordered by priority. Example: if a user has
     // a license subsidy, we use that as the user's final subsidy. if not, we check

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -155,7 +155,7 @@ export default class CourseService {
 
   /**
    * Returns an offer whose catalog uuid matches one of the provided catalogs.
-   * Note: This method currently cannot help discover if the offer applies specifically
+   * TODO: This method currently cannot help discover if the offer applies specifically
    * to a course, just that there is an offer that matches one in the list of catalogs.
    * @param {Object} args Arguments
    * @param {Array<Offer>} args.offers All offers for this user for an enterprise

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -154,6 +154,9 @@ export default class CourseService {
       usage_type: "Percentage"
       */
     const offerForCourse = findOfferForCourse(offers, catalogList);
+    if (!offerForCourse) {
+      return Promise.reject(new Error('No offer found'));
+    }
     const {
       usageType, benefitValue, couponStartDate, couponEndDate,
     } = offerForCourse;

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -40,7 +40,7 @@ export default class CourseService {
     const courseDetails = camelCaseObject(data[0]);
     // Get the user subsidy (by license, codes, or any other means) that the user may have for the active course run
     this.activeCourseRun = this.activeCourseRun || getActiveCourseRun(courseDetails);
-    const userSubsidy = await this.fetchEnterpriseUserSubsidy();
+    const userSubsidyApplicableToCourse = await this.fetchEnterpriseUserSubsidy();
     // Check for the course_run_key URL param and remove all other course run data
     // if the given course run key is for an available course run.
     if (this.courseRunKey) {
@@ -56,7 +56,7 @@ export default class CourseService {
 
     return {
       courseDetails,
-      userSubsidy,
+      userSubsidyApplicableToCourse,
       userEnrollments: data[1],
       userEntitlements: data[2].results,
       catalog: data[3],
@@ -104,14 +104,14 @@ export default class CourseService {
     // a non-200 status code.
     const data = await Promise.allSettled(promises);
 
-    let userSubsidy = null;
+    let userSubsidyApplicableToCourse = null;
     for (let i = 0; i < data.length; i++) {
       if (data[i]?.status === PROMISE_FULFILLED) {
         const result = data[i].value.data;
         const subsidyData = camelCaseObject(result);
 
         if (hasValidStartExpirationDates(subsidyData)) {
-          userSubsidy = { ...subsidyData, subsidyType: SUBSIDY_TYPES[i].type };
+          userSubsidyApplicableToCourse = { ...subsidyData, subsidyType: SUBSIDY_TYPES[i].type };
           // if a non-expired user subsidy is found, break early since the promises
           // are priority ordered
           break;
@@ -119,7 +119,7 @@ export default class CourseService {
       }
     }
 
-    return userSubsidy;
+    return userSubsidyApplicableToCourse;
   }
 
   fetchUserLicenseSubsidy() {

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -142,17 +142,27 @@ export default class CourseService {
     return this.cachedAuthenticatedHttpClient.get(url);
   }
 
+  /**
+   * @typedef {Object} Offer An offer for a course
+   * @property {string} usageType
+   * @property {number} benefitValue
+   * @property {string} couponStartDate utc formatted
+   * @property {string} couponEndDate utc formatted
+   * @property {number} redemptionsRemaining
+   * @property {string} code
+   * @property {string} catalog uuid of catalog
+   */
+
+  /**
+   * Returns an offer whose catalog uuid matches one of the provided catalogs.
+   * Note: This method currently cannot help discover if the offer applies specifically
+   * to a course, just that there is an offer that matches one in the list of catalogs.
+   * @param {Object} args Arguments
+   * @param {Array<Offer>} args.offers All offers for this user for an enterprise
+   *
+   * @returns {Promise} a promise that resolves to an object matching userSubsidyApplicableToCourse
+   */
   fetchUserOfferSubsidy({ offers, catalogList }) {
-    // TODO this probably should be a fetch but we are using prefetch offer data here
-    /*
-      benefit_value: 100
-      catalog: "09a6dd6a-a6f0-4232-aaca-3bd1d81a4197"
-      code: "3K64Q2MP6VYAWFJ5"
-      coupon_end_date: "2025-09-24T00:00:00Z"
-      coupon_start_date: "2020-09-24T00:00:00Z"
-      redemptions_remaining: 1
-      usage_type: "Percentage"
-      */
     const offerForCourse = findOfferForCourse(offers, catalogList);
     if (!offerForCourse) {
       return Promise.reject(new Error('No offer found'));

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -23,7 +23,7 @@ describe('useCourseEnrollmentUrl', () => {
     subscriptionLicense: {
       uuid: 'yes',
     },
-    userSubsidy: {
+    userSubsidyApplicableToCourse: {
       subsidyType: LICENSE_SUBSIDY_TYPE,
     },
   };
@@ -39,7 +39,7 @@ describe('useCourseEnrollmentUrl', () => {
 
     test('does not use the license uuid for enrollment if there is no valid license subsidy (even with a license uuid)', () => {
       const noSubsidyEnrollmentInputs = { ...enrollmentInputs };
-      delete noSubsidyEnrollmentInputs.userSubsidy;
+      delete noSubsidyEnrollmentInputs.userSubsidyApplicableToCourse;
 
       const { result } = renderHook(() => useCourseEnrollmentUrl(noSubsidyEnrollmentInputs));
       expect(result.current).not.toContain(enrollmentInputs.subscriptionLicense.uuid);

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -6,6 +6,7 @@ import {
   COURSE_PACING_MAP,
   COURSE_MODES_MAP,
   LICENSE_SUBSIDY_TYPE,
+  OFFER_SUBSIDY_TYPE,
 } from './constants';
 
 import MicroMastersSvgIcon from '../../../assets/icons/micromasters.svg';
@@ -182,4 +183,8 @@ export function shouldUpgradeUserEnrollment({
 
 export function hasLicenseSubsidy(subsidy) {
   return subsidy?.subsidyType === LICENSE_SUBSIDY_TYPE;
+}
+
+export function hasOfferSubsidy(subsidy) {
+  return subsidy?.subsidyType === OFFER_SUBSIDY_TYPE;
 }

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -115,6 +115,7 @@ describe('Sidebar price display with hideCourseOriginalPrice ON', () => {
   });
 });
 
+// We only test price here, since messages are already tested above
 describe('Sidebar price display with hideCourseOriginalPrice OFF', () => {
   test('no subsidies, shows original price, no messages', () => {
     render(<SidebarWithContext
@@ -122,8 +123,6 @@ describe('Sidebar price display with hideCourseOriginalPrice OFF', () => {
       initialAppState={appStateWithOrigPriceShowing}
     />);
     expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
-    expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
-    expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
   });
   test('subscription license subsidy, shows orig crossed out price, correct message', () => {
     render(<SidebarWithContext
@@ -148,7 +147,5 @@ describe('Sidebar price display with hideCourseOriginalPrice OFF', () => {
     />);
     expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
     expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
-    expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
-    expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
   });
 });

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -52,6 +52,20 @@ const SidebarWithContext = ({ initialState, userSubsidyState = { offers: [] } })
 );
 
 describe('Sidebar price for various use cases', () => {
+  const SUBSIDY_WITH_MATCHING_OFFER = {
+    offers: {
+      offers: [{
+        code: 'bearsRus', catalog: 'bears', benefitValue: 100, usageType: 'Percentage',
+      }],
+    },
+  };
+  const SUBSIDY_WITHOUT_MATCHING_OFFER = {
+    offers: {
+      offers: [{
+        code: 'bearsRus', catalog: 'bulls', benefitValue: 100, usageType: 'Percentage',
+      }],
+    },
+  };
   test('when license subsidy is found, must show subscription price and message', () => {
     render(<SidebarWithContext initialState={courseStateWithLicenseSubsidy} />);
     expect(screen.getByText('Included in your subscription')).toBeInTheDocument();
@@ -59,20 +73,22 @@ describe('Sidebar price for various use cases', () => {
   test('when license subsidy is absent, but offer found, must show offer price and message', () => {
     render(<SidebarWithContext
       initialState={courseStateWithOffersNoLicenseSubsidy}
-      userSubsidyState={{
-        offers: {
-          offers: [{
-            code: 'bearsRus', catalog: 'bears', benefitValue: 100, usageType: 'Percentage',
-          }],
-        },
-      }}
+      userSubsidyState={SUBSIDY_WITH_MATCHING_OFFER}
     />);
-    expect(screen.getByText(/Sponsored by/)).toBeInTheDocument();
+    expect(screen.getByText('Sponsored by')).toBeInTheDocument();
+  });
+  test('when license subsidy is absent, and matching offer not found, must show original price and message', () => {
+    render(<SidebarWithContext
+      initialState={courseStateWithOffersNoLicenseSubsidy}
+      userSubsidyState={SUBSIDY_WITHOUT_MATCHING_OFFER}
+    />);
+    expect(screen.queryByText('Sponsored by')).not.toBeInTheDocument();
+    expect(screen.getByText(/\$1.00/)).toBeInTheDocument();
   });
   test('when license subsidy and offers are absent, must show original price and message', () => {
     render(<SidebarWithContext initialState={courseStateWithNoOffersNoLicenseSubsidy} />);
-    expect(screen.getByText(/1.00/)).toBeInTheDocument();
-    expect(screen.queryByText(/Sponsored by/)).not.toBeInTheDocument();
+    expect(screen.getByText(/\$1.00/)).toBeInTheDocument();
+    expect(screen.queryByText('Sponsored by')).not.toBeInTheDocument();
     expect(screen.queryByText('Included in your subscription')).not.toBeInTheDocument();
   });
 });

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -72,5 +72,7 @@ describe('Sidebar price for various use cases', () => {
   test('when license subsidy and offers are absent, must show original price and message', () => {
     render(<SidebarWithContext initialState={courseStateWithNoOffersNoLicenseSubsidy} />);
     expect(screen.getByText(/1.00/)).toBeInTheDocument();
+    expect(screen.queryByText(/Sponsored by/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Included in your subscription')).not.toBeInTheDocument();
   });
 });

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -18,6 +18,29 @@ const courseStateWithLicenseSubsidy = {
     firstEnrollablePaidSeatPrice: 1,
   },
   userSubsidy: { subsidyType: LICENSE_SUBSIDY_TYPE },
+  course: {},
+  userEnrollments: [],
+  userEntitlements: [],
+};
+
+const courseStateWithOffersNoLicenseSubsidy = {
+  activeCourseRun: {
+    firstEnrollablePaidSeatPrice: 1,
+  },
+  course: {},
+  userEnrollments: [],
+  userEntitlements: [],
+  userSubsidy: {},
+};
+
+const courseStateWithNoOffersNoLicenseSubsidy = {
+  activeCourseRun: {
+    firstEnrollablePaidSeatPrice: 1,
+  },
+  course: {},
+  userEnrollments: [],
+  userEntitlements: [],
+  userSubsidy: {},
 };
 
 // eslint-disable-next-line react/prop-types
@@ -35,9 +58,11 @@ describe('Sidebar price for various use cases', () => {
     expect(screen.getByText('Included in your subscription')).toBeInTheDocument();
   });
   test('when license subsidy is absent, but offer found, must show offer price and message', () => {
-    render(<SidebarWithContext initialState={courseStateWithLicenseSubsidy} />);
+    render(<SidebarWithContext initialState={courseStateWithOffersNoLicenseSubsidy} />);
+    expect(screen.getByText(/Sponsored by /)).toBeInTheDocument();
   });
   test('when license subsidy and offers are absent, must show original price and message', () => {
-    render(<SidebarWithContext initialState={courseStateWithLicenseSubsidy} />);
+    render(<SidebarWithContext initialState={courseStateWithNoOffersNoLicenseSubsidy} />);
+    expect(screen.getByText(/1.00/)).toBeInTheDocument();
   });
 });

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { AppContext } from '@edx/frontend-platform/react';
+import { CourseContextProvider } from '../CourseContextProvider';
+import CourseSidebarPrice from '../CourseSidebarPrice';
+import { LICENSE_SUBSIDY_TYPE } from '../data/constants';
+
+const initialAppState = {
+  enterpriseConfig: {
+    slug: 'test-enterprise-slug',
+  },
+};
+
+const courseStateWithLicenseSubsidy = {
+  activeCourseRun: {
+    firstEnrollablePaidSeatPrice: 1,
+  },
+  userSubsidy: { subsidyType: LICENSE_SUBSIDY_TYPE },
+};
+
+// eslint-disable-next-line react/prop-types
+const SidebarWithContext = ({ initialState }) => (
+  <AppContext.Provider value={initialAppState}>
+    <CourseContextProvider initialState={initialState}>
+      <CourseSidebarPrice />
+    </CourseContextProvider>
+  </AppContext.Provider>
+);
+
+describe('Sidebar price for various use cases', () => {
+  test('when license subsidy is found, must show subscription price and message', () => {
+    render(<SidebarWithContext initialState={courseStateWithLicenseSubsidy} />);
+    expect(screen.getByText('Included in your subscription')).toBeInTheDocument();
+  });
+  test('when license subsidy is absent, but offer found, must show offer price and message', () => {
+    render(<SidebarWithContext initialState={courseStateWithLicenseSubsidy} />);
+  });
+  test('when license subsidy and offers are absent, must show original price and message', () => {
+    render(<SidebarWithContext initialState={courseStateWithLicenseSubsidy} />);
+  });
+});

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -14,36 +14,29 @@ const initialAppState = {
   },
 };
 
-const courseStateWithLicenseSubsidy = {
+const BASE_COURSE_STATE = {
   activeCourseRun: {
     firstEnrollablePaidSeatPrice: 1,
   },
-  userSubsidy: { subsidyType: LICENSE_SUBSIDY_TYPE },
+  userSubsidy: {},
   course: {},
   userEnrollments: [],
   userEntitlements: [],
   catalog: [],
 };
 
+const courseStateWithLicenseSubsidy = {
+  ...BASE_COURSE_STATE,
+  userSubsidy: { subsidyType: LICENSE_SUBSIDY_TYPE },
+};
+
 const courseStateWithOffersNoLicenseSubsidy = {
-  activeCourseRun: {
-    firstEnrollablePaidSeatPrice: 1,
-  },
-  course: {},
-  userEnrollments: [],
-  userEntitlements: [],
-  userSubsidy: {},
+  ...BASE_COURSE_STATE,
   catalog: { catalogList: ['bears'] },
 };
 
 const courseStateWithNoOffersNoLicenseSubsidy = {
-  activeCourseRun: {
-    firstEnrollablePaidSeatPrice: 1,
-  },
-  course: {},
-  userEnrollments: [],
-  userEntitlements: [],
-  userSubsidy: {},
+  ...BASE_COURSE_STATE,
   catalog: { catalogList: ['bears'] },
 };
 

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -17,6 +17,14 @@ const appStateWithOrigPriceHidden = {
   },
 };
 
+const appStateWithOrigPriceShowing = {
+  ...appStateWithOrigPriceHidden,
+  enterpriseConfig: {
+    ...appStateWithOrigPriceHidden.enterpriseConfig,
+    hideCourseOriginalPrice: false,
+  },
+};
+
 const BASE_COURSE_STATE = {
   activeCourseRun: {
     firstEnrollablePaidSeatPrice: 7.50,
@@ -65,6 +73,13 @@ SidebarWithContext.propTypes = {
 };
 
 const SPONSORED_BY_TEXT = 'Sponsored by test-enterprise';
+const SUBSIDY_WITH_MATCHING_OFFER = {
+  offers: {
+    offers: [{
+      code: 'bearsRus', catalog: 'bears', benefitValue: 90, usageType: 'Percentage',
+    }],
+  },
+};
 
 describe('Sidebar price display with hideCourseOriginalPrice ON', () => {
   test('no subsidies, hides original price, no messages', () => {
@@ -80,13 +95,6 @@ describe('Sidebar price display with hideCourseOriginalPrice ON', () => {
     expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
   });
   test('offer 100% subsidy, shows no price, correct message', () => {
-    const SUBSIDY_WITH_MATCHING_OFFER = {
-      offers: {
-        offers: [{
-          code: 'bearsRus', catalog: 'bears', benefitValue: 100, usageType: 'Percentage',
-        }],
-      },
-    };
     render(<SidebarWithContext
       initialCourseState={courseStateWithOffersNoLicenseSubsidy}
       userSubsidyState={SUBSIDY_WITH_MATCHING_OFFER}
@@ -97,17 +105,48 @@ describe('Sidebar price display with hideCourseOriginalPrice ON', () => {
     expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
   });
   test('offer non-full subsidy, shows discounted price only, correct message', () => {
-    const SUBSIDY_WITH_MATCHING_OFFER = {
-      offers: {
-        offers: [{
-          code: 'bearsRus', catalog: 'bears', benefitValue: 90, usageType: 'Percentage',
-        }],
-      },
-    };
     render(<SidebarWithContext
       initialCourseState={courseStateWithOffersNoLicenseSubsidy}
       userSubsidyState={SUBSIDY_WITH_MATCHING_OFFER}
     />);
+    expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
+    expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
+    expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
+  });
+});
+
+describe('Sidebar price display with hideCourseOriginalPrice OFF', () => {
+  test('no subsidies, shows original price, no messages', () => {
+    render(<SidebarWithContext
+      initialCourseState={courseStateWithNoOffersNoLicenseSubsidy}
+      initialAppState={appStateWithOrigPriceShowing}
+    />);
+    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+    expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
+    expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
+  });
+  test('subscription license subsidy, shows orig crossed out price, correct message', () => {
+    render(<SidebarWithContext
+      initialCourseState={courseStateWithLicenseSubsidy}
+      initialAppState={appStateWithOrigPriceShowing}
+    />);
+    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+  });
+  test('offer 100% subsidy, shows orig price, correct message', () => {
+    render(<SidebarWithContext
+      initialAppState={appStateWithOrigPriceShowing}
+      initialCourseState={courseStateWithOffersNoLicenseSubsidy}
+      userSubsidyState={SUBSIDY_WITH_MATCHING_OFFER}
+    />);
+    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+  });
+  test('offer non-full subsidy, shows orig and discounted price only, correct message', () => {
+    render(<SidebarWithContext
+      initialAppState={appStateWithOrigPriceShowing}
+      initialCourseState={courseStateWithOffersNoLicenseSubsidy}
+      userSubsidyState={SUBSIDY_WITH_MATCHING_OFFER}
+    />);
+    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
     expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
     expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
     expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -81,13 +81,16 @@ const SUBSIDY_WITH_MATCHING_OFFER = {
   },
 };
 
-describe('Sidebar price display with hideCourseOriginalPrice ON', () => {
-  test('no subsidies, hides original price, no messages', () => {
+describe('Sidebar price display with hideCourseOriginalPrice ON, No subsidies', () => {
+  test('no subsidies, shows original price, no messages', () => {
     render(<SidebarWithContext initialCourseState={courseStateWithNoOffersNoLicenseSubsidy} />);
-    expect(screen.queryByText(/\$7.50 USD/)).not.toBeInTheDocument();
+    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
     expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
     expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
   });
+});
+
+describe('Sidebar price display with hideCourseOriginalPrice ON', () => {
   test('subscription license subsidy, shows no price, correct message', () => {
     render(<SidebarWithContext initialCourseState={courseStateWithLicenseSubsidy} />);
     expect(screen.queryByText(/\$7.50 USD/)).not.toBeInTheDocument();

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';
 import { CourseContextProvider } from '../CourseContextProvider';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy/UserSubsidy';
-import CourseSidebarPrice from '../CourseSidebarPrice';
+import CourseSidebarPrice, { INCLUDED_IN_SUBSCRIPTION_MESSAGE } from '../CourseSidebarPrice';
 import { LICENSE_SUBSIDY_TYPE } from '../data/constants';
 
 const initialAppState = {
@@ -68,7 +68,7 @@ describe('Sidebar price for various use cases', () => {
   };
   test('when license subsidy is found, must show subscription price and message', () => {
     render(<SidebarWithContext initialState={courseStateWithLicenseSubsidy} />);
-    expect(screen.getByText('Included in your subscription')).toBeInTheDocument();
+    expect(screen.getByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).toBeInTheDocument();
   });
   test('when license subsidy is absent, but offer found, must show offer price and message', () => {
     render(<SidebarWithContext
@@ -89,6 +89,6 @@ describe('Sidebar price for various use cases', () => {
     render(<SidebarWithContext initialState={courseStateWithNoOffersNoLicenseSubsidy} />);
     expect(screen.getByText(/\$1.00/)).toBeInTheDocument();
     expect(screen.queryByText('Sponsored by')).not.toBeInTheDocument();
-    expect(screen.queryByText('Included in your subscription')).not.toBeInTheDocument();
+    expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
   });
 });

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -29,7 +29,7 @@ const BASE_COURSE_STATE = {
   activeCourseRun: {
     firstEnrollablePaidSeatPrice: 7.50,
   },
-  userSubsidy: {},
+  userSubsidyApplicableToCourse: {},
   course: {},
   userEnrollments: [],
   userEntitlements: [],
@@ -38,7 +38,7 @@ const BASE_COURSE_STATE = {
 
 const courseStateWithLicenseSubsidy = {
   ...BASE_COURSE_STATE,
-  userSubsidy: { subsidyType: LICENSE_SUBSIDY_TYPE },
+  userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
 };
 
 const courseStateWithOffersNoLicenseSubsidy = {

--- a/src/components/course/tests/EnrollButton.test.jsx
+++ b/src/components/course/tests/EnrollButton.test.jsx
@@ -59,7 +59,7 @@ describe('<EnrollButton />', () => {
     },
     userEnrollments: [],
     userEntitlements: [],
-    userSubsidy: { subsidyType: LICENSE_SUBSIDY_TYPE },
+    userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
     catalog: {},
   };
   const initialUserSubsidyState = {


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-3632

this mainly changes how the price display look for non subscription  (offer) cases, adds test cases etc.

pre-merge checklist:
- [ ] Joe C to sign off on screenshots!
- [x] Also going to chat with Ange today to confirm the desired behavior of the crossed out price for 100% discount offer case. Otherwise we are looking good!


Added test cases for:

feature flag off (should show original price)

feature flag on (should hide original price)

And test cases both scenarios:
- With an offer code that applies to the course:
- With a subscription that includes the course
- With no offers that apply to the course and no subscription


Screenshots:


### No subscription, offer 100% discount, hide orig price disabled

<img width="620" alt="Screen Shot 2021-01-20 at 10 26 12 PM" src="https://user-images.githubusercontent.com/528166/105276114-a3594980-5b6e-11eb-8222-177faa66baa2.png">

### No subscription, but matching offer 100% discount, hide orig price enabled
only shows message, no price (since it would be $0)

<img width="912" alt="Screen Shot 2021-01-25 at 2 54 10 PM" src="https://user-images.githubusercontent.com/528166/105758441-43232880-5f1d-11eb-859f-3572aa4a36d6.png">

### No subscription, partial offer, hide orig price disabled

<img width="763" alt="Screen Shot 2021-01-25 at 2 57 23 PM" src="https://user-images.githubusercontent.com/528166/105758807-ae6cfa80-5f1d-11eb-8317-2c4125b6256f.png">

### No subscription, partial offer, hide orig price enabled

<img width="722" alt="Screen Shot 2021-01-25 at 2 58 24 PM" src="https://user-images.githubusercontent.com/528166/105758899-cba1c900-5f1d-11eb-8e25-5d96755f5264.png">

### No subsidies apply (ignores the flag)

<img width="863" alt="Screen Shot 2021-01-21 at 2 25 24 PM" src="https://user-images.githubusercontent.com/528166/105401786-8ff0c180-5bf4-11eb-91f3-95e9834c9c0b.png">


