### PR TITLE
ENT-3950 and ENT-3951 Bug fix: passing in missing filter for user offers by uuid.

### DIFF
--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -51,7 +51,11 @@ export function useOffers(enterpriseId) {
   useEffect(
     () => {
       if (features.ENROLL_WITH_CODES) {
-        fetchOffers(`enterprise_uuid=${enterpriseId}&full_discount_only=True`, dispatch);
+        fetchOffers({
+          enterprise_uuid: enterpriseId,
+          full_discount_only: 'True', // Must be a string because the API does a string compare not a true JSON boolean compare.
+        },
+          dispatch);
       }
     },
     [enterpriseId],

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -51,7 +51,7 @@ export function useOffers(enterpriseId) {
   useEffect(
     () => {
       if (features.ENROLL_WITH_CODES) {
-        fetchOffers('full_discount_only=True', dispatch);
+        fetchOffers(`enterprise_uuid=${enterpriseId}&full_discount_only=True`, dispatch);
       }
     },
     [enterpriseId],

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -55,7 +55,7 @@ export function useOffers(enterpriseId) {
           enterprise_uuid: enterpriseId,
           full_discount_only: 'True', // Must be a string because the API does a string compare not a true JSON boolean compare.
         },
-          dispatch);
+        dispatch);
       }
     },
     [enterpriseId],

--- a/src/components/enterprise-user-subsidy/offers/data/actions.js
+++ b/src/components/enterprise-user-subsidy/offers/data/actions.js
@@ -26,10 +26,10 @@ const fetchOffersFailure = error => ({
   },
 });
 
-const fetchOffers = (query, dispatch) => {
+const fetchOffers = (queryOptions, dispatch) => {
   dispatch(fetchOffersRequest());
 
-  return service.fetchOffers(query)
+  return service.fetchOffers(queryOptions)
     .then((response) => {
       dispatch(fetchOffersSuccess(camelCaseObject(response.data)));
     })

--- a/src/components/enterprise-user-subsidy/offers/data/service.js
+++ b/src/components/enterprise-user-subsidy/offers/data/service.js
@@ -1,7 +1,9 @@
+import qs from 'query-string';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
-const fetchOffers = (query) => {
+const fetchOffers = (queryOptions) => {
+  const query = qs.stringify(queryOptions);
   const config = getConfig();
   const offersUrl = `${config.ECOMMERCE_BASE_URL}/api/v2/enterprise/offer_assignment_summary/?${query}`;
   const httpClient = getAuthenticatedHttpClient({

--- a/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
@@ -137,6 +137,7 @@ describe('UserSubsidy', () => {
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, "full_discount_only": "True" });
       await waitFor(() => {
         expect(screen.queryByText('Has access: false')).toBeInTheDocument();
       });
@@ -162,6 +163,8 @@ describe('UserSubsidy', () => {
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, "full_discount_only": "True" });
+
       await waitFor(() => {
         expect(screen.queryByText('Has access: true')).toBeInTheDocument();
       });
@@ -187,6 +190,8 @@ describe('UserSubsidy', () => {
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, "full_discount_only": "True" });
+
       await waitFor(() => {
         expect(screen.queryByText(`License status: ${LICENSE_STATUS.ACTIVATED}`)).toBeInTheDocument();
       });
@@ -213,6 +218,8 @@ describe('UserSubsidy', () => {
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledTimes(1);
+      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, "full_discount_only": "True" });
+
       await waitFor(() => {
         expect(screen.queryByText('Offers count: 0')).toBeInTheDocument();
       });

--- a/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
@@ -137,7 +137,7 @@ describe('UserSubsidy', () => {
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
-      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, "full_discount_only": "True" });
+      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, full_discount_only: 'True' });
       await waitFor(() => {
         expect(screen.queryByText('Has access: false')).toBeInTheDocument();
       });
@@ -163,7 +163,7 @@ describe('UserSubsidy', () => {
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
-      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, "full_discount_only": "True" });
+      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, full_discount_only: 'True' });
 
       await waitFor(() => {
         expect(screen.queryByText('Has access: true')).toBeInTheDocument();
@@ -190,7 +190,7 @@ describe('UserSubsidy', () => {
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
-      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, "full_discount_only": "True" });
+      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, full_discount_only: 'True' });
 
       await waitFor(() => {
         expect(screen.queryByText(`License status: ${LICENSE_STATUS.ACTIVATED}`)).toBeInTheDocument();
@@ -218,7 +218,7 @@ describe('UserSubsidy', () => {
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledTimes(1);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledTimes(1);
-      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, "full_discount_only": "True" });
+      expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, full_discount_only: 'True' });
 
       await waitFor(() => {
         expect(screen.queryByText('Offers count: 0')).toBeInTheDocument();


### PR DESCRIPTION
Added missing query param. @raq929 and @adamstankiewicz I welcome suggestions on how to test/regression test this because it's not testable by frontend unit test and also the backend is fine. This seems like an e2e candidate perhaps? 

Addresses ENT-3950 and ENT-3951 