### PR TITLE
Changing the cache time for code requests to 30 seconds

### DIFF
--- a/src/components/enterprise-user-subsidy/offers/data/service.js
+++ b/src/components/enterprise-user-subsidy/offers/data/service.js
@@ -6,10 +6,7 @@ const fetchOffers = (queryOptions) => {
   const query = qs.stringify(queryOptions);
   const config = getConfig();
   const offersUrl = `${config.ECOMMERCE_BASE_URL}/api/v2/enterprise/offer_assignment_summary/?${query}`;
-  const httpClient = getAuthenticatedHttpClient({
-    useCache: config.USE_API_CACHE,
-  });
-  return httpClient.get(offersUrl);
+  return getAuthenticatedHttpClient().get(offersUrl);
 };
 
 export { fetchOffers };


### PR DESCRIPTION
[Jira Ticket](https://openedx.atlassian.net/browse/ENT-3952)

Situation: when a user spends their coupon on a course and then are assigned a new code and refresh the page, they do not see the new code assigned to them.

Problem: default caching expiries meant that the request for user coupons was stale for 5 minutes. So if a user is assigned a new code after using another one, they wouldn't rerequest their number of codes until the 5 minutes is/was up.

Solution: Remove the cache