### PR TITLE
bug: ENT-3997 make discountType check case-safe

### DIFF
--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -195,11 +195,13 @@ const useCoursePriceForUserSubsidy = ({
         const { discountType, discountValue } = userSubsidyApplicableToCourse;
         let discountedPrice;
 
-        if (discountType && discountType.toLowerCase() === SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE) {
+        if (discountType
+            && discountType.toLowerCase() === SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE.toLowerCase()) {
           discountedPrice = listPrice - (listPrice * (discountValue / 100));
         }
 
-        if (discountType && discountType.toLowerCase() === SUBSIDY_DISCOUNT_TYPE_MAP.ABSOLUTE) {
+        if (discountType
+            && discountType.toLowerCase() === SUBSIDY_DISCOUNT_TYPE_MAP.ABSOLUTE.toLowerCase()) {
           discountedPrice = Math.max(listPrice - discountValue, 0);
         }
 

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -195,11 +195,11 @@ const useCoursePriceForUserSubsidy = ({
         const { discountType, discountValue } = userSubsidyApplicableToCourse;
         let discountedPrice;
 
-        if (discountType === SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE) {
+        if (discountType && discountType.toLowerCase() === SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE) {
           discountedPrice = listPrice - (listPrice * (discountValue / 100));
         }
 
-        if (discountType === SUBSIDY_DISCOUNT_TYPE_MAP.ABSOLUTE) {
+        if (discountType && discountType.toLowerCase() === SUBSIDY_DISCOUNT_TYPE_MAP.ABSOLUTE) {
           discountedPrice = Math.max(listPrice - discountValue, 0);
         }
 

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -44,6 +44,7 @@ const courseStateWithLicenseSubsidy = {
   userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
 };
 
+// making discountType uppercase to help validate case-safe check in hooks logic
 const FULL_OFFER_SUBSIDY = {
   discountType: SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE.toUpperCase(),
   discountValue: 100,

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -45,7 +45,7 @@ const courseStateWithLicenseSubsidy = {
 };
 
 const FULL_OFFER_SUBSIDY = {
-  discountType: SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE,
+  discountType: SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE.toUpperCase(),
   discountValue: 100,
   subsidyType: OFFER_SUBSIDY_TYPE,
 };


### PR DESCRIPTION
really that the backend response contains 

```
usage_type: Percentage
```

while the code checks for 'percentage', so making the check case-insensitive is probably the best idea.