### PR TITLE
Refactor enroll button part I: hook functions ENT-3889

### DIFF
--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -237,6 +237,21 @@ useCoursePriceForUserSubsidy.propTypes = {
   }).isRequired,
 };
 
+/**
+ * Get enrollment url for a particular course
+ *
+ * @param {object} args Arguments.
+ * @param {Array.<object>} args.catalogList list of catalogs
+ * @param {object} args.enterpriseConfig config for enterprise
+ * @param {string} args.key course key
+ * @param {object} args.location just an object with a 'search' field (usually from useLocation())
+ * @param {Array.<object>} args.offers array of offer objects for course
+ * @param {string} args.sku course SKU
+ * @param {object} args.subscriptionLicense license for subscription | null
+ * @param {object} args.userSubsidyApplicableToCourse subsidy for course if found | null
+ *
+ * @returns {string} url for enrollment
+ */
 export function useCourseEnrollmentUrl({
   catalogList,
   enterpriseConfig,

--- a/src/components/course/enrollment/constants.js
+++ b/src/components/course/enrollment/constants.js
@@ -1,0 +1,11 @@
+const enrollButtonTypesLocal = {
+  ENROLL_DISABLED: 'enroll_disabled',
+  TO_COURSEWARE_PAGE: 'to_courseware_page',
+  VIEW_ON_DASHBOARD: 'view_on_dashboard',
+  TO_DATASHARING_CONSENT: 'to_datasharing_consent',
+  TO_ECOM_BASKET: 'to_ecom_basket',
+  TO_VOUCHER_REDEEM: 'to_voucher_redeem',
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const enrollButtonTypes = Object.freeze(enrollButtonTypesLocal);

--- a/src/components/course/enrollment/hooks.js
+++ b/src/components/course/enrollment/hooks.js
@@ -1,0 +1,109 @@
+import { useMemo, useContext } from 'react';
+
+import { AppContext } from '@edx/frontend-platform/react';
+
+import { UserSubsidyContext } from '../../enterprise-user-subsidy/UserSubsidy';
+import { useCourseEnrollmentUrl } from '../data/hooks';
+import { CourseContext } from '../CourseContextProvider';
+import {
+  findHighestLevelSeatSku, findOfferForCourse, hasCourseStarted, findUserEnrollmentForCourse,
+} from '../data/utils';
+
+/**
+ * Enrollment data needed for enroll logic
+ * @typedef {Object} EnrollmentData
+ * @property {boolean} isUserEnrolled
+ * @property {boolean} isCourseStarted
+ * @property {boolean} isEnrollable
+ * @property {object} userEnrollment
+ */
+
+/**
+ *
+ * Extracts info needed for enroll button logic from CourseContext, for a single course.
+ * Which course?
+ *   `activeCourseRun`, `userEnrollments` are looked up in the CourseContext's `state`
+ *
+ * @returns {EnrollmentData} enrolldata data for use in enrollment logic
+ */
+export function useEnrollData() {
+  const { state: courseData } = useContext(CourseContext);
+  const { activeCourseRun, userEnrollments } = courseData;
+  const { key, start, isEnrollable } = activeCourseRun;
+
+  const isCourseStarted = useMemo(
+    () => hasCourseStarted(start),
+    [start],
+  );
+
+  const userEnrollment = useMemo(
+    () => findUserEnrollmentForCourse({ userEnrollments, key }),
+    [userEnrollments, key],
+  );
+  return {
+    isEnrollable,
+    isUserEnrolled: !!userEnrollment,
+    isCourseStarted,
+    userEnrollment,
+  };
+}
+
+/**
+ * Extract subsidy information from CourseContext and UserSubsidyContext.
+ * Before calling this, ensure required data is in CourseContext, UserSubsidyContext and AppContext
+ *
+ * CourseContext: must have `state` with `activeCourseRun`, `userSubsidy` and `catalog`
+ * AppContext: must have `enterpriseConfig` populated
+ * UserSubsidyContext: must have `subscriptionLicense`, `offers` populated
+ *
+ * @param { object } location router location. Only here because of useEnrollmentUrl hook.
+ *   (TODO Refactor this once useEnrollmentUrl is refactored!)
+ *
+ * @returns {object} with fields:
+ * {
+ *    subscriptionLicense,
+ *    userSubsidy,
+ *    enrollmentUrl,
+ *    offersCount,
+*     courseHasOffer,
+ * }
+ */
+export function useSubsidyData({ location }) {
+  const { state: courseData } = useContext(CourseContext);
+  const { enterpriseConfig } = useContext(AppContext);
+  const { subscriptionLicense, offers: { offers, offersCount } } = useContext(UserSubsidyContext);
+
+  const {
+    activeCourseRun,
+    userSubsidy,
+    catalog: { catalogList },
+  } = courseData;
+  const {
+    key,
+    seats,
+  } = activeCourseRun;
+
+  const sku = useMemo(
+    () => findHighestLevelSeatSku(seats),
+    [seats],
+  );
+
+  const enrollmentUrl = useCourseEnrollmentUrl({
+    catalogList,
+    enterpriseConfig,
+    key,
+    location,
+    offers,
+    sku,
+    subscriptionLicense,
+    userSubsidy,
+  });
+
+  return {
+    subscriptionLicense,
+    userSubsidy,
+    enrollmentUrl,
+    offersCount,
+    courseHasOffer: !!findOfferForCourse(offers, catalogList),
+  };
+}

--- a/src/components/course/enrollment/hooks.js
+++ b/src/components/course/enrollment/hooks.js
@@ -50,59 +50,26 @@ export function useEnrollData() {
 
 /**
  * Extract subsidy information from CourseContext and UserSubsidyContext.
- * Before calling this, ensure required data is in CourseContext, UserSubsidyContext and AppContext
- *
- * CourseContext: must have `state` with `activeCourseRun`, `userSubsidy` and `catalog`
- * AppContext: must have `enterpriseConfig` populated
- * UserSubsidyContext: must have `subscriptionLicense`, `offers` populated
- *
- * @param { object } location router location. Only here because of useEnrollmentUrl hook.
- *   (TODO Refactor this once useEnrollmentUrl is refactored!)
+ * Before calling this, ensure the following data is in CourseContext and UserSubsidyContext:
+ *   CourseContext `state` should have `userSubsidyApplicableToCourse` and `catalog`
+ *   UserSubsidyContext `value` should have `subscriptionLicense` and `offers`
  *
  * @returns {object} with fields:
  * {
  *    subscriptionLicense,
  *    userSubsidyApplicableToCourse,
- *    enrollmentUrl,
  *    offersCount,
 *     courseHasOffer,
  * }
  */
-export function useSubsidyData({ location }) {
+export function useSubsidyData() {
   const { state: courseData } = useContext(CourseContext);
-  const { enterpriseConfig } = useContext(AppContext);
   const { subscriptionLicense, offers: { offers, offersCount } } = useContext(UserSubsidyContext);
 
-  const {
-    activeCourseRun,
-    userSubsidyApplicableToCourse,
-    catalog: { catalogList },
-  } = courseData;
-  const {
-    key,
-    seats,
-  } = activeCourseRun;
-
-  const sku = useMemo(
-    () => findHighestLevelSeatSku(seats),
-    [seats],
-  );
-
-  const enrollmentUrl = useCourseEnrollmentUrl({
-    catalogList,
-    enterpriseConfig,
-    key,
-    location,
-    offers,
-    sku,
-    subscriptionLicense,
-    userSubsidyApplicableToCourse,
-  });
-
+  const { userSubsidyApplicableToCourse, catalog: { catalogList } } = courseData;
   return {
     subscriptionLicense,
     userSubsidyApplicableToCourse,
-    enrollmentUrl,
     offersCount,
     courseHasOffer: !!findOfferForCourse(offers, catalogList),
   };

--- a/src/components/course/enrollment/hooks.js
+++ b/src/components/course/enrollment/hooks.js
@@ -1,12 +1,9 @@
 import { useMemo, useContext } from 'react';
 
-import { AppContext } from '@edx/frontend-platform/react';
-
 import { UserSubsidyContext } from '../../enterprise-user-subsidy/UserSubsidy';
-import { useCourseEnrollmentUrl } from '../data/hooks';
 import { CourseContext } from '../CourseContextProvider';
 import {
-  findHighestLevelSeatSku, findOfferForCourse, hasCourseStarted, findUserEnrollmentForCourse,
+  findOfferForCourse, hasCourseStarted, findUserEnrollmentForCourse,
 } from '../data/utils';
 
 /**

--- a/src/components/course/enrollment/hooks.js
+++ b/src/components/course/enrollment/hooks.js
@@ -62,7 +62,7 @@ export function useEnrollData() {
  * @returns {object} with fields:
  * {
  *    subscriptionLicense,
- *    userSubsidy,
+ *    userSubsidyApplicableToCourse,
  *    enrollmentUrl,
  *    offersCount,
 *     courseHasOffer,
@@ -75,7 +75,7 @@ export function useSubsidyData({ location }) {
 
   const {
     activeCourseRun,
-    userSubsidy,
+    userSubsidyApplicableToCourse,
     catalog: { catalogList },
   } = courseData;
   const {
@@ -96,12 +96,12 @@ export function useSubsidyData({ location }) {
     offers,
     sku,
     subscriptionLicense,
-    userSubsidy,
+    userSubsidyApplicableToCourse,
   });
 
   return {
     subscriptionLicense,
-    userSubsidy,
+    userSubsidyApplicableToCourse,
     enrollmentUrl,
     offersCount,
     courseHasOffer: !!findOfferForCourse(offers, catalogList),

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import PropTypes from 'prop-types';
+
+import { CourseContextProvider } from '../../CourseContextProvider';
+import { useEnrollData } from '../hooks';
+
+const BASE_COURSE_STATE = {
+  activeCourseRun: {
+    firstEnrollablePaidSeatPrice: 7.50,
+    key: 'course_key',
+    start: '2020-02-12T10:00:00Z',
+    isEnrollable: true,
+  },
+  userSubsidyApplicableToCourse: null,
+  course: {},
+  userEnrollments: [],
+  userEntitlements: [],
+  catalog: [],
+};
+
+// Needed to render our hook with context initialized
+const wrapper = ({ children, initialState }) => (
+  <CourseContextProvider initialState={initialState}>{children}</CourseContextProvider>
+);
+
+wrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  initialState: PropTypes.shape({}).isRequired,
+};
+
+describe('useEnrollData tests', () => {
+  test('correct extraction of enroll fields', () => {
+    const userEnrollment = undefined;
+    const isEnrollable = false;
+    const expected = {
+      isEnrollable,
+      isUserEnrolled: false, // since no userEnrollments are passed
+      isCourseStarted: true, // since date in past
+      userEnrollment,
+    };
+
+    const initialState = {
+      ...BASE_COURSE_STATE,
+      activeCourseRun: {
+        ...BASE_COURSE_STATE.activeCourseRun,
+        isEnrollable,
+      },
+    };
+
+    const { result } = renderHook(() => useEnrollData(), {
+      wrapper,
+      initialProps: { initialState },
+    });
+    expect(result.current).toStrictEqual(expected);
+  });
+});

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -44,27 +44,18 @@ describe('useEnrollData tests', () => {
 });
 
 describe('useSubsidyData tests', () => {
-  const ENTERPRISE_SLUG = 'test-enterprise-slug';
   const LICENSE_UUID = 'test-license-uuid';
+  const subscriptionLicense = { uuid: LICENSE_UUID };
 
   test('correct extraction of subsidy fields from UserSubsidyContext', () => {
     const expected = {
       courseHasOffer: false,
-      enrollmentUrl: null,
       offersCount: 0,
-      subscriptionLicense: { uuid: LICENSE_UUID },
+      subscriptionLicense,
       userSubsidyApplicableToCourse: BASE_COURSE_STATE.userSubsidyApplicableToCourse,
     };
-    const initialAppState = {
-      enterpriseConfig: {
-        uuid: 'abc123',
-        slug: ENTERPRISE_SLUG,
-      },
-    };
     const initialUserSubsidyState = {
-      subscriptionLicense: {
-        uuid: 'test-license-uuid',
-      },
+      subscriptionLicense,
       offers: {
         offers: [],
         offersCount: 0,
@@ -73,14 +64,11 @@ describe('useSubsidyData tests', () => {
     // Needed to render our hook with context initialized
     // eslint-disable-next-line react/prop-types
     const wrapper = ({ children }) => (
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <CourseContextProvider initialState={BASE_COURSE_STATE}>{children}</CourseContextProvider>
-        </UserSubsidyContext.Provider>
-      </AppContext.Provider>
+      <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+        <CourseContextProvider initialState={BASE_COURSE_STATE}>{children}</CourseContextProvider>
+      </UserSubsidyContext.Provider>
     );
-    const location = { search: 'x=1' };
-    const { result } = renderHook(() => useSubsidyData({ location }), { wrapper });
+    const { result } = renderHook(() => useSubsidyData(), { wrapper });
     expect(result.current).toStrictEqual(expected);
   });
 });

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 
-import { AppContext } from '@edx/frontend-platform/react';
-
 import { CourseContextProvider } from '../../CourseContextProvider';
 import { UserSubsidyContext } from '../../../enterprise-user-subsidy';
 

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -44,18 +44,21 @@ describe('useEnrollData tests', () => {
 });
 
 describe('useSubsidyData tests', () => {
+  const ENTERPRISE_SLUG = 'test-enterprise-slug';
+  const LICENSE_UUID = 'test-license-uuid';
+
   test('correct extraction of subsidy fields from UserSubsidyContext', () => {
     const expected = {
       courseHasOffer: false,
       enrollmentUrl: null,
       offersCount: 0,
-      subscriptionLicense: { uuid: 'test-license-uuid' },
+      subscriptionLicense: { uuid: LICENSE_UUID },
       userSubsidyApplicableToCourse: BASE_COURSE_STATE.userSubsidyApplicableToCourse,
     };
     const initialAppState = {
       enterpriseConfig: {
         uuid: 'abc123',
-        slug: 'test-enterprise-slug',
+        slug: ENTERPRISE_SLUG,
       },
     };
     const initialUserSubsidyState = {

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import PropTypes from 'prop-types';
 
 import { CourseContextProvider } from '../../CourseContextProvider';
 import { useEnrollData } from '../hooks';
@@ -10,7 +9,7 @@ const BASE_COURSE_STATE = {
     firstEnrollablePaidSeatPrice: 7.50,
     key: 'course_key',
     start: '2020-02-12T10:00:00Z',
-    isEnrollable: true,
+    isEnrollable: false,
   },
   userSubsidyApplicableToCourse: null,
   course: {},
@@ -19,38 +18,24 @@ const BASE_COURSE_STATE = {
   catalog: [],
 };
 
-// Needed to render our hook with context initialized
-const wrapper = ({ children, initialState }) => (
-  <CourseContextProvider initialState={initialState}>{children}</CourseContextProvider>
-);
-
-wrapper.propTypes = {
-  children: PropTypes.node.isRequired,
-  initialState: PropTypes.shape({}).isRequired,
-};
-
 describe('useEnrollData tests', () => {
   test('correct extraction of enroll fields', () => {
     const userEnrollment = undefined;
-    const isEnrollable = false;
     const expected = {
-      isEnrollable,
+      isEnrollable: false,
       isUserEnrolled: false, // since no userEnrollments are passed
       isCourseStarted: true, // since date in past
       userEnrollment,
     };
 
-    const initialState = {
-      ...BASE_COURSE_STATE,
-      activeCourseRun: {
-        ...BASE_COURSE_STATE.activeCourseRun,
-        isEnrollable,
-      },
-    };
+    // Needed to render our hook with context initialized
+    // eslint-disable-next-line react/prop-types
+    const wrapper = ({ children }) => (
+      <CourseContextProvider initialState={BASE_COURSE_STATE}>{children}</CourseContextProvider>
+    );
 
     const { result } = renderHook(() => useEnrollData(), {
       wrapper,
-      initialProps: { initialState },
     });
     expect(result.current).toStrictEqual(expected);
   });

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 
+import { AppContext } from '@edx/frontend-platform/react';
+
 import { CourseContextProvider } from '../../CourseContextProvider';
-import { useEnrollData } from '../hooks';
+import { UserSubsidyContext } from '../../../enterprise-user-subsidy';
+
+import { useEnrollData, useSubsidyData } from '../hooks';
 
 const BASE_COURSE_STATE = {
   activeCourseRun: {
@@ -34,9 +38,46 @@ describe('useEnrollData tests', () => {
       <CourseContextProvider initialState={BASE_COURSE_STATE}>{children}</CourseContextProvider>
     );
 
-    const { result } = renderHook(() => useEnrollData(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => useEnrollData(), { wrapper });
+    expect(result.current).toStrictEqual(expected);
+  });
+});
+
+describe('useSubsidyData tests', () => {
+  test('correct extraction of subsidy fields from UserSubsidyContext', () => {
+    const expected = {
+      courseHasOffer: false,
+      enrollmentUrl: null,
+      offersCount: 0,
+      subscriptionLicense: { uuid: 'test-license-uuid' },
+      userSubsidyApplicableToCourse: BASE_COURSE_STATE.userSubsidyApplicableToCourse,
+    };
+    const initialAppState = {
+      enterpriseConfig: {
+        uuid: 'abc123',
+        slug: 'test-enterprise-slug',
+      },
+    };
+    const initialUserSubsidyState = {
+      subscriptionLicense: {
+        uuid: 'test-license-uuid',
+      },
+      offers: {
+        offers: [],
+        offersCount: 0,
+      },
+    };
+    // Needed to render our hook with context initialized
+    // eslint-disable-next-line react/prop-types
+    const wrapper = ({ children }) => (
+      <AppContext.Provider value={initialAppState}>
+        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+          <CourseContextProvider initialState={BASE_COURSE_STATE}>{children}</CourseContextProvider>
+        </UserSubsidyContext.Provider>
+      </AppContext.Provider>
+    );
+    const location = { search: 'x=1' };
+    const { result } = renderHook(() => useSubsidyData({ location }), { wrapper });
     expect(result.current).toStrictEqual(expected);
   });
 });


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-3889

### What's in here

Just two hook functions that handle enrollment data, and subsidy data respectively. These outputs will be used in the main logic flow that is coming up in the next PR. Ref: https://openedx.atlassian.net/wiki/spaces/SOL/pages/2178875970/Enroll+Button+logic+for+Enterprise+Learner+Portal

No ui component work here, second PR will handle that and cleaning out the use of the old component as well.

Also incorporates hooks related feedback I already got from @adamstankiewicz on this [older, bulkier PR ](https://github.com/edx/frontend-app-learner-portal-enterprise/pull/171/files)(not going to submit it, other than to ensure I take care of any feedback from there)

I am pulling out enrollment url calculation from the user subsidy hook since it's unrelated and will be called directly by the new EnrollButton ui component, thus eliminating the need to depend on `location` in this hook (which was freaking me out!)
