### PR TITLE
set subscriptionPlan to null if the enterprise config comes back as null

### DIFF
--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { identify } from 'react-fullstory';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { AppContext } from '@edx/frontend-platform/react';
+import { AppContext, ErrorPage } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import { LoadingSpinner } from '../loading-spinner';
@@ -17,7 +17,7 @@ import {
 
 export default function EnterprisePage({ children }) {
   const { enterpriseSlug } = useParams();
-  const enterpriseConfig = useEnterpriseCustomerConfig(enterpriseSlug);
+  const [enterpriseConfig, fetchError] = useEnterpriseCustomerConfig(enterpriseSlug);
   const subscriptionPlan = useEnterpriseCustomerSubscriptionPlan(enterpriseConfig);
 
   const user = getAuthenticatedUser();
@@ -41,8 +41,10 @@ export default function EnterprisePage({ children }) {
     );
   }
 
-  // We explicitly set enterpriseConfig to null if there is no configuration, the learner portal is
-  // not enabled, or there was an error fetching the configuration. In all these cases, we want to 404.
+  if (fetchError) {
+    return <ErrorPage message={fetchError.message} />;
+  }
+
   if (isDefinedAndNull(enterpriseConfig)) {
     return <NotFoundPage />;
   }

--- a/src/components/enterprise-page/data/tests/customerConfig.test.js
+++ b/src/components/enterprise-page/data/tests/customerConfig.test.js
@@ -74,13 +74,14 @@ describe('customer config with various states of branding_configuration', () => 
 
     // since there is an async fetch in the hook
     await waitForNextUpdate();
+    const customerConfig = result.current[0];
 
     expect(result.error).not.toBeDefined();
-    expect(result.current).not.toBeNull();
-    expect(result.current.branding.logo).toBeNull();
-    expect(result.current.branding.colors.primary).toBe(defaultPrimaryColor);
-    expect(result.current.branding.colors.secondary).toBe(defaultSecondaryColor);
-    expect(result.current.branding.colors.tertiary).toBe(defaultTertiaryColor);
+    expect(customerConfig).not.toBeNull();
+    expect(customerConfig.branding.logo).toBeNull();
+    expect(customerConfig.branding.colors.primary).toBe(defaultPrimaryColor);
+    expect(customerConfig.branding.colors.secondary).toBe(defaultSecondaryColor);
+    expect(customerConfig.branding.colors.tertiary).toBe(defaultTertiaryColor);
   });
 
   test('null values for fields in branding_config uses defaults and does not fail', async () => {
@@ -90,13 +91,14 @@ describe('customer config with various states of branding_configuration', () => 
 
     // since there is an async fetch in the hook
     await waitForNextUpdate();
+    const customerConfig = result.current[0];
 
     expect(result.error).not.toBeDefined();
-    expect(result.current).not.toBeNull();
-    expect(result.current.branding.logo).toBeNull();
-    expect(result.current.branding.colors.primary).toBe(defaultPrimaryColor);
-    expect(result.current.branding.colors.secondary).toBe(defaultSecondaryColor);
-    expect(result.current.branding.colors.tertiary).toBe(defaultTertiaryColor);
+    expect(customerConfig).not.toBeNull();
+    expect(customerConfig.branding.logo).toBeNull();
+    expect(customerConfig.branding.colors.primary).toBe(defaultPrimaryColor);
+    expect(customerConfig.branding.colors.secondary).toBe(defaultSecondaryColor);
+    expect(customerConfig.branding.colors.tertiary).toBe(defaultTertiaryColor);
   });
 
   test('valid branding_config results in correct values for logo and other branding settings', async () => {
@@ -105,12 +107,13 @@ describe('customer config with various states of branding_configuration', () => 
     const { result, waitForNextUpdate } = renderHook(() => useEnterpriseCustomerConfig(TEST_ENTERPRISE_SLUG));
 
     await waitForNextUpdate();
+    const customerConfig = result.current[0];
 
     expect(result.error).not.toBeDefined();
     expect(result.current).not.toBeNull();
-    expect(result.current.branding.logo).toBe('testlogo.png');
-    expect(result.current.branding.colors.primary).toBe(defaultPrimaryColor);
-    expect(result.current.branding.colors.secondary).toBe('secondaryColor');
-    expect(result.current.branding.colors.tertiary).toBe('tertiaryColor');
+    expect(customerConfig.branding.logo).toBe('testlogo.png');
+    expect(customerConfig.branding.colors.primary).toBe(defaultPrimaryColor);
+    expect(customerConfig.branding.colors.secondary).toBe('secondaryColor');
+    expect(customerConfig.branding.colors.tertiary).toBe('tertiaryColor');
   });
 });


### PR DESCRIPTION
When the enterprise config came back as null the spinner on the page would keep spinning, this change makes the page display a 404 instead.