### PR TITLE
Pass in override to blank out sidebar text in our flow.

### DIFF
--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -288,6 +288,8 @@ export function useCourseEnrollmentUrl({
         const enrollOptions = {
           ...baseEnrollmentOptions,
           sku,
+          left_sidebar_text: '', // We don't want a sidebar when we call the data consent page from this t
+
         };
         // get the index of the first offer that applies to a catalog that the course is in
         const offerForCourse = findOfferForCourse(offers, catalogList);

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -288,7 +288,8 @@ export function useCourseEnrollmentUrl({
         const enrollOptions = {
           ...baseEnrollmentOptions,
           sku,
-          left_sidebar_text: '', // We don't want a sidebar when we call the data consent page from this t
+          // We don't want any sidebar text we show the data consent page from this workflow:
+          left_sidebar_text: ''
 
         };
         // get the index of the first offer that applies to a catalog that the course is in

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -289,7 +289,7 @@ export function useCourseEnrollmentUrl({
           ...baseEnrollmentOptions,
           sku,
           // We don't want any sidebar text we show the data consent page from this workflow:
-          left_sidebar_text: '',
+          left_sidebar_text_override: '',
 
         };
         // get the index of the first offer that applies to a catalog that the course is in

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -289,7 +289,7 @@ export function useCourseEnrollmentUrl({
           ...baseEnrollmentOptions,
           sku,
           // We don't want any sidebar text we show the data consent page from this workflow:
-          left_sidebar_text: ''
+          left_sidebar_text: '',
 
         };
         // get the index of the first offer that applies to a catalog that the course is in


### PR DESCRIPTION
To support ticket ENT-4024, in which we want the ability to override the explanatory text that appears in the sidebar with a query option. Note: requires edx-enterprise change that accepts this parameter or nothing will happen. Screenshot attached. 

Requires: https://github.com/edx/edx-enterprise/pull/1161 