### PR TITLE
ENT-4185: pass offers to useCourseEnrollmentUrl hook, tests

### DIFF
--- a/src/components/course/EnrollButton.jsx
+++ b/src/components/course/EnrollButton.jsx
@@ -20,6 +20,7 @@ export default function EnrollButton() {
     subscriptionLicense,
     userSubsidyApplicableToCourse,
     courseHasOffer,
+    offers,
   } = useSubsidyDataForCourse();
   const location = useLocation();
 
@@ -54,6 +55,7 @@ export default function EnrollButton() {
     enterpriseConfig,
     key,
     location,
+    offers,
     sku,
     subscriptionLicense,
     userSubsidyApplicableToCourse,

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -312,7 +312,7 @@ useCourseEnrollmentUrl.propTypes = {
   enterpriseConfig: PropTypes.shape({}).isRequired,
   key: PropTypes.string.isRequired,
   location: PropTypes.shape({}).isRequired,
-  offers: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  offers: PropTypes.arrayOf(PropTypes.shape({})),
   sku: PropTypes.string.isRequired,
   subscriptionLicense: PropTypes.shape({}).isRequired,
   userSubsidyApplicableToCourse: PropTypes.shape({}).isRequired,

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -252,16 +252,16 @@ useCoursePriceForUserSubsidy.propTypes = {
  *
  * @returns {string} url for enrollment
  */
-export function useCourseEnrollmentUrl({
+const useCourseEnrollmentUrl = ({
   catalogList,
   enterpriseConfig,
   key,
   location,
-  offers,
+  offers = [],
   sku,
   subscriptionLicense,
   userSubsidyApplicableToCourse,
-}) {
+}) => {
   const config = getConfig();
   const enrollmentFailedParams = { ...qs.parse(location.search) };
   enrollmentFailedParams[ENROLLMENT_FAILED_QUERY_PARAM] = true;
@@ -305,6 +305,17 @@ export function useCourseEnrollmentUrl({
   );
 
   return enrollmentUrl;
-}
+};
 
-export { useCoursePriceForUserSubsidy };
+useCourseEnrollmentUrl.propTypes = {
+  catalogList: PropTypes.shape({}).isRequired,
+  enterpriseConfig: PropTypes.shape({}).isRequired,
+  key: PropTypes.string.isRequired,
+  location: PropTypes.shape({}).isRequired,
+  offers: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  sku: PropTypes.string.isRequired,
+  subscriptionLicense: PropTypes.shape({}).isRequired,
+  userSubsidyApplicableToCourse: PropTypes.shape({}).isRequired,
+};
+
+export { useCoursePriceForUserSubsidy, useCourseEnrollmentUrl };

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -18,6 +18,16 @@ describe('useCourseEnrollmentUrl', () => {
     catalogList: ['bears'],
     location: { search: 'foo' },
   };
+  // just skip the offers here to ensure we process absence correctly
+  const noOffersEnrollmentInputs = {
+    enterpriseConfig: {
+      uuid: 'foo',
+    },
+    key: 'bar',
+    sku: 'xkcd',
+    catalogList: ['bears'],
+    location: { search: 'foo' },
+  };
   const enrollmentInputs = {
     ...noSubscriptionEnrollmentInputs,
     subscriptionLicense: {
@@ -70,6 +80,15 @@ describe('useCourseEnrollmentUrl', () => {
       const { result } = renderHook(() => useCourseEnrollmentUrl({
         ...noSubscriptionEnrollmentInputs,
         offers: [],
+      }));
+      expect(result.current).toContain(process.env.ECOMMERCE_BASE_URL);
+      expect(result.current).toContain(noSubscriptionEnrollmentInputs.sku);
+      expect(result.current).toContain(enrollmentInputs.key);
+      expect(result.current).not.toContain('code');
+    });
+    test('with no offers passed, treats it as empty offers and does not fail', () => {
+      const { result } = renderHook(() => useCourseEnrollmentUrl({
+        ...noOffersEnrollmentInputs,
       }));
       expect(result.current).toContain(process.env.ECOMMERCE_BASE_URL);
       expect(result.current).toContain(noSubscriptionEnrollmentInputs.sku);

--- a/src/components/course/enrollment/hooks.js
+++ b/src/components/course/enrollment/hooks.js
@@ -56,7 +56,8 @@ export function useEnrollData() {
  *    subscriptionLicense,
  *    userSubsidyApplicableToCourse,
  *    offersCount,
-*     courseHasOffer,
+ *    offers,
+ *     courseHasOffer,
  * }
  */
 export function useSubsidyDataForCourse() {
@@ -68,6 +69,7 @@ export function useSubsidyDataForCourse() {
     subscriptionLicense,
     userSubsidyApplicableToCourse,
     offersCount,
+    offers,
     courseHasOffer: !!findOfferForCourse(offers, catalogList),
   };
 }

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -76,6 +76,7 @@ describe('useSubsidyDataForCourse', () => {
     const expected = {
       courseHasOffer: false,
       offersCount: 0,
+      offers: [],
       subscriptionLicense,
       userSubsidyApplicableToCourse: BASE_COURSE_STATE.userSubsidyApplicableToCourse,
     };
@@ -101,6 +102,7 @@ describe('useSubsidyDataForCourse', () => {
       courseHasOffer: true,
       offersCount: 1,
       subscriptionLicense,
+      offers: [{ catalog: 'catalog-1', discountValue: 10 }],
       userSubsidyApplicableToCourse: BASE_COURSE_STATE.userSubsidyApplicableToCourse,
     };
     const initialUserSubsidyState = {

--- a/src/components/course/tests/EnrollButton.test.jsx
+++ b/src/components/course/tests/EnrollButton.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { AppContext } from '@edx/frontend-platform/react';
+import {
+  renderWithRouter,
+  initialAppState,
+  initialCourseState,
+} from '../../../utils/tests';
+
+import { COURSE_MODES_MAP } from '../data/constants';
+import EnrollButton from '../EnrollButton';
+import { CourseContextProvider } from '../CourseContextProvider';
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+
+jest.mock('../../../config', () => ({
+  features: { ENROLL_WITH_CODES: true },
+}));
+
+const INITIAL_APP_STATE = initialAppState({});
+const defaultCourse = initialCourseState({});
+
+const selfPacedCourseWithoutLicenseSubsidy = {
+  ...defaultCourse,
+  userSubsidyApplicableToCourse: null,
+  activeCourseRun: {
+    ...defaultCourse.activeCourseRun,
+    seats: [{ sku: 'sku', type: COURSE_MODES_MAP.VERIFIED }],
+  },
+  catalog: { catalogList: [] },
+};
+
+describe('Enroll Button behavior', () => {
+  const renderButton = ({
+    AnEnrollButton,
+    courseInitState = selfPacedCourseWithoutLicenseSubsidy,
+    initialUserSubsidyState = {
+      subscriptionLicense: null, // required to test offers case correctly!
+      offers: {
+        offers: [{ discountValue: 90 }],
+        offersCount: 0,
+      },
+    },
+  }) => {
+    // need to use router, to render component such as react-router's <Link>
+    renderWithRouter(
+      <AppContext.Provider value={INITIAL_APP_STATE}>
+        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+          <CourseContextProvider initialState={courseInitState}>
+            {AnEnrollButton}
+          </CourseContextProvider>
+        </UserSubsidyContext.Provider>
+      </AppContext.Provider>,
+    );
+  };
+  test.only('when there is no license subsidy, and there is an offer, url should be rendered', () => {
+    renderButton({ AnEnrollButton: <EnrollButton /> });
+    expect(screen.getByText('Enroll')).toBeInTheDocument();
+    // instead of directly testing the mock call of useCourseEnrollmentUrl,
+    // we test that we do render the hyperlink correctly
+    expect(screen.getByText('Continue to payment')).toBeInTheDocument();
+  });
+});

--- a/src/components/course/tests/EnrollButton.test.jsx
+++ b/src/components/course/tests/EnrollButton.test.jsx
@@ -57,7 +57,7 @@ describe('Enroll Button behavior', () => {
     renderButton({ AnEnrollButton: <EnrollButton /> });
     expect(screen.getByText('Enroll')).toBeInTheDocument();
     // instead of directly testing the mock call of useCourseEnrollmentUrl,
-    // we test that we do render the hyperlink correctly
+    // we test that we do render the contents of the real component (to_courseware_page) correctly
     expect(screen.getByText('Continue to payment')).toBeInTheDocument();
   });
 });

--- a/src/components/course/tests/EnrollButton.test.jsx
+++ b/src/components/course/tests/EnrollButton.test.jsx
@@ -53,7 +53,7 @@ describe('Enroll Button behavior', () => {
       </AppContext.Provider>,
     );
   };
-  test.only('when there is no license subsidy, and there is an offer, url should be rendered', () => {
+  test('when there is no license subsidy, and there is an offer, url should be rendered', () => {
     renderButton({ AnEnrollButton: <EnrollButton /> });
     expect(screen.getByText('Enroll')).toBeInTheDocument();
     // instead of directly testing the mock call of useCourseEnrollmentUrl,


### PR DESCRIPTION
__JIRA__: ENT-4185

Fixes the bug as reported during bug bash when no learner subscription is active, subscription plan is active for enterprise, and there exists at least one offer

when there are offers, but no active license, the useCourseEnrollmentUrl fails, due to absence of the offers parameter. It does not have a default value right now so it fails when checking `offers.length`

This PR includes:

* adds a default empty array as a default value so absence is treated as if there are no offers, just for defensive coding
* passes the offers param from useSubsidyData hook into the above hook for proper operation of the logic
* tests that the component renders correctly without an error in the absence of license subsidy, but presence of offers in the context


### Testing notes

Reproduced bug using ticket instructions and once I put the current changes in, the page loads successfully, tests also pass
