### PR TITLE
feat: create root route that redirects to appropriate slug, if any

### DIFF
--- a/src/components/NotFoundPage/index.jsx
+++ b/src/components/NotFoundPage/index.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { AppContext } from '@edx/frontend-platform/react';
+import { Container } from '@edx/paragon';
 
 const NotFoundPage = () => {
   const { enterpriseConfig } = useContext(AppContext);
@@ -11,14 +12,14 @@ const NotFoundPage = () => {
   }
 
   return (
-    <div className="container-fluid mt-3">
+    <Container className="mt-3">
       <Helmet title={PAGE_TITLE} />
       <div className="text-center py-5">
         <h1>404</h1>
         <p className="lead">Oops, sorry we can&apos;t find that page!</p>
         <p>Either something went wrong or the page doesn&apos;t exist anymore.</p>
       </div>
-    </div>
+    </Container>
   );
 };
 

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Switch } from 'react-router-dom';
-import { AppProvider, PageRoute } from '@edx/frontend-platform/react';
-import { getConfig } from '@edx/frontend-platform/config';
-import FullStory from 'react-fullstory';
+import { AppProvider, AuthenticatedPageRoute, PageRoute } from '@edx/frontend-platform/react';
 
-import { DashboardPage } from '../dashboard';
 import NotFoundPage from '../NotFoundPage';
+import { EnterpriseCustomerRedirect } from '../enterprise-customer-redirect';
+import { DashboardPage } from '../dashboard';
 import { CoursePage } from '../course';
 import { SearchPage } from '../search';
 import { LicenseActivationPage } from '../license-activation';
@@ -13,17 +12,14 @@ import { LicenseActivationPage } from '../license-activation';
 import store from '../../store';
 
 export default function App() {
-  const { FULLSTORY_ORG_ID } = getConfig();
   return (
     <AppProvider store={store}>
-      {FULLSTORY_ORG_ID && (
-        <FullStory org={FULLSTORY_ORG_ID} />
-      )}
       <Switch>
         <PageRoute exact path="/:enterpriseSlug" component={DashboardPage} />
         <PageRoute exact path="/:enterpriseSlug/search" component={SearchPage} />
         <PageRoute exact path="/:enterpriseSlug/course/:courseKey" component={CoursePage} />
         <PageRoute exact path="/:enterpriseSlug/licenses/:activationKey/activate" component={LicenseActivationPage} />
+        <AuthenticatedPageRoute exact path="/" component={EnterpriseCustomerRedirect} />
         <PageRoute path="*" component={NotFoundPage} />
       </Switch>
     </AppProvider>

--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { useLocation } from 'react-router-dom';
 import qs from 'query-string';
-import { Breadcrumb, StatusAlert } from '@edx/paragon';
+import { Breadcrumb, Container, StatusAlert } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { CourseContext } from './CourseContextProvider';
@@ -39,7 +39,7 @@ export default function CourseHeader() {
 
   const renderFailedEnrollmentAlert = () => (
     <>
-      <div className="container-fluid pt-3">
+      <Container className="pt-3">
         <StatusAlert
           alertType="danger"
           className="mb-0"
@@ -53,14 +53,14 @@ export default function CourseHeader() {
           dismissible={false}
           open
         />
-      </div>
+      </Container>
     </>
   );
 
   return (
     <div className="course-header">
       {enrollmentFailed && renderFailedEnrollmentAlert()}
-      <div className="container-fluid">
+      <Container>
         <div className="row py-4">
           <div className="col-12 col-lg-7">
             {primarySubject && (
@@ -131,7 +131,7 @@ export default function CourseHeader() {
             </div>
           )}
         </div>
-      </div>
+      </Container>
     </div>
   );
 }

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -2,7 +2,9 @@ import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
 import MediaQuery from 'react-responsive';
-import { Container, StatusAlert, Row, breakpoints } from '@edx/paragon';
+import {
+  Container, StatusAlert, Row, breakpoints,
+} from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { IntegrationWarningModal } from '../integration-warning-modal';

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
 import MediaQuery from 'react-responsive';
-import { StatusAlert, breakpoints } from '@edx/paragon';
+import { Container, StatusAlert, Row, breakpoints } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { IntegrationWarningModal } from '../integration-warning-modal';
@@ -39,9 +39,9 @@ export default function Dashboard() {
   return (
     <>
       <Helmet title={PAGE_TITLE} />
-      <div className="container-fluid py-5">
+      <Container className="py-5">
         {state?.activationSuccess && renderLicenseActivationSuccess()}
-        <div className="row">
+        <Row>
           <MainContent>
             <DashboardMainContent />
           </MainContent>
@@ -54,8 +54,8 @@ export default function Dashboard() {
           </MediaQuery>
           <IntegrationWarningModal isOpen={enterpriseConfig.showIntegrationWarning} />
           {subscriptionPlan && <SubscriptionExpirationModal />}
-        </div>
-      </div>
+        </Row>
+      </Container>
     </>
   );
 }

--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
+import { Container } from '@edx/paragon';
 
 import './styles/EnterpriseBanner.scss';
 
@@ -7,11 +8,11 @@ export default function EnterpriseBanner() {
   const { enterpriseConfig } = useContext(AppContext);
   return (
     <div className="enterprise-banner bg-brand-secondary">
-      <div className="container-fluid">
+      <Container>
         <h1 className="h2 mb-0 py-3 pl-3 border-brand-tertiary text-brand-secondary">
           {enterpriseConfig.name}
         </h1>
-      </div>
+      </Container>
     </div>
   );
 }

--- a/src/components/enterprise-customer-redirect/EnterpriseCustomerRedirect.jsx
+++ b/src/components/enterprise-customer-redirect/EnterpriseCustomerRedirect.jsx
@@ -1,0 +1,36 @@
+import React, { useContext } from 'react';
+import { Redirect } from 'react-router-dom';
+import { AppContext } from '@edx/frontend-platform/react';
+
+import NotFoundPage from '../NotFoundPage';
+import { LoadingSpinner } from '../loading-spinner';
+
+import {
+  useEnterpriseCustomersForUser,
+  useSelectedEnterpriseUUIDByUserRoles,
+  useEnterpriseCustomerSlugByUUID,
+} from './data/hooks';
+
+const EnterpriseCustomerRedirect = () => {
+  const { authenticatedUser } = useContext(AppContext);
+  const { userId, roles } = authenticatedUser;
+  const { enterpriseCustomers, isLoading } = useEnterpriseCustomersForUser(userId);
+  const selectedEnterpriseUUID = useSelectedEnterpriseUUIDByUserRoles(roles);
+  const selectedEnterpriseSlug = useEnterpriseCustomerSlugByUUID(selectedEnterpriseUUID, enterpriseCustomers);
+
+  if (isLoading) {
+    return (
+      <div className="py-5">
+        <LoadingSpinner screenReaderText="loading my linked organizations" />
+      </div>
+    );
+  }
+
+  if (!selectedEnterpriseSlug) {
+    return <NotFoundPage />;
+  }
+
+  return <Redirect to={`/${selectedEnterpriseSlug}`} />;
+};
+
+export default EnterpriseCustomerRedirect;

--- a/src/components/enterprise-customer-redirect/data/hooks.js
+++ b/src/components/enterprise-customer-redirect/data/hooks.js
@@ -22,6 +22,7 @@ export const useEnterpriseCustomersForUser = (userId) => {
       if (!userId) {
         return;
       }
+
       fetchEnterpriseCustomersForUser()
         .then((response) => {
           const data = camelCaseObject(response.data);

--- a/src/components/enterprise-customer-redirect/data/hooks.js
+++ b/src/components/enterprise-customer-redirect/data/hooks.js
@@ -1,0 +1,78 @@
+import { useEffect, useState, useMemo } from 'react';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { fetchEnterpriseCustomersForUser } from './service';
+
+/**
+ * A React hook that will fetch all the enterprise customers linked to the specified user id.
+ *
+ * @param {*} userId A user's id.
+ *
+ * @returns {list} obj.enterpriseCustomers A list of enterprise customers associated with a user. Note this is empty
+ *  until the fetch promise has finished resolving.
+ * @returns {bool} obj.isLoading A Boolean for whether the request is pending.
+ */
+export const useEnterpriseCustomersForUser = (userId) => {
+  const [enterpriseCustomers, setEnterpriseCustomers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(
+    () => {
+      if (!userId) {
+        return;
+      }
+      fetchEnterpriseCustomersForUser()
+        .then((response) => {
+          const data = camelCaseObject(response.data);
+          const results = data?.results || [];
+          setEnterpriseCustomers(results);
+        })
+        .catch((error) => {
+          logError(`EnterpriseCustomerRedirect could not fetch enterprise customers: ${error.message}`);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    },
+    [userId],
+  );
+
+  return { enterpriseCustomers, isLoading };
+};
+
+/**
+ * Determines a user's selected enterprise customer given their JWT roles.
+ *
+ * @param {array} userRoles List of edx-rbac roles for the user.
+ *
+ * @returns {string} The user's selected enterprise UUID for their session.
+ */
+export const useSelectedEnterpriseUUIDByUserRoles = (userRoles) => {
+  const selectedEnterpriseRole = useMemo(
+    () => userRoles.find((role) => {
+      const parts = role.split(':');
+      return parts[0] === 'enterprise_learner';
+    }),
+    [userRoles],
+  );
+
+  const selectedEnterpriseUUID = selectedEnterpriseRole?.split(':')[1];
+  return selectedEnterpriseUUID;
+};
+
+/**
+ * Finds the enterprise customer's slug for a given enterprise UUID.
+ *
+ * @param {string} uuid An enterprise customer UUID
+ * @param {array} enterpriseCustomers List of enterprise customers linked to the user.
+ *
+ * @returns {string} The slug of the enterprise matching the given UUID.
+ */
+export const useEnterpriseCustomerSlugByUUID = (uuid, enterpriseCustomers) => {
+  const enterpriseCustomer = useMemo(
+    () => enterpriseCustomers?.find(customer => customer?.uuid === uuid),
+    [uuid, enterpriseCustomers],
+  );
+  return enterpriseCustomer?.slug;
+};

--- a/src/components/enterprise-customer-redirect/data/service.js
+++ b/src/components/enterprise-customer-redirect/data/service.js
@@ -1,0 +1,8 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform/config';
+
+export function fetchEnterpriseCustomersForUser() {
+  const config = getConfig();
+  const url = `${config.LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/`;
+  return getAuthenticatedHttpClient().get(url);
+}

--- a/src/components/enterprise-customer-redirect/index.js
+++ b/src/components/enterprise-customer-redirect/index.js
@@ -1,0 +1,1 @@
+export { default as EnterpriseCustomerRedirect } from './EnterpriseCustomerRedirect';

--- a/src/components/enterprise-customer-redirect/tests/EnterpriseCustomerRedirect.test.jsx
+++ b/src/components/enterprise-customer-redirect/tests/EnterpriseCustomerRedirect.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
-import { screen, act, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import EnterpriseCustomerRedirect from '../EnterpriseCustomerRedirect';

--- a/src/components/enterprise-customer-redirect/tests/EnterpriseCustomerRedirect.test.jsx
+++ b/src/components/enterprise-customer-redirect/tests/EnterpriseCustomerRedirect.test.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { screen, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import EnterpriseCustomerRedirect from '../EnterpriseCustomerRedirect';
+
+import { fetchEnterpriseCustomersForUser } from '../data/service';
+
+import { renderWithRouter } from '../../../utils/tests';
+
+jest.mock('../data/service');
+
+const responseWithEmptyEnterpriseCustomers = {
+  data: {
+    results: [],
+  },
+};
+
+const TEST_ENTERPRISES = [
+  {
+    uuid: 'some-fake-uuid',
+    name: 'Test Enterprise',
+    slug: 'test-enterprise',
+  },
+  {
+    uuid: 'another-fake-uuid',
+    name: 'Another Enterprise',
+    slug: 'another-enterprise',
+  },
+];
+const responseWithIndividualEnterpriseCustomer = {
+  data: {
+    results: [TEST_ENTERPRISES[0]],
+  },
+};
+const responseWithSeveralEnterpriseCustomers = {
+  data: {
+    results: TEST_ENTERPRISES,
+  },
+};
+
+/* eslint-disable react/prop-types */
+const EnterpriseCustomerRedirectWithContext = ({
+  initialAppState = {},
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <EnterpriseCustomerRedirect />
+  </AppContext.Provider>
+);
+/* eslint-enable react/prop-types */
+
+describe('<EnterpriseCustomerRedirect />', () => {
+  const initialAppState = {
+    authenticatedUser: {
+      userId: 1,
+      roles: [],
+    },
+    config: {
+      LMS_BASE_URL: process.env.LMS_BASE_URL,
+    },
+  };
+
+  beforeEach(() => {
+    fetchEnterpriseCustomersForUser.mockClear();
+  });
+
+  test('renders NotFoundPage if user is not linked to any Enterprise Customers', async () => {
+    fetchEnterpriseCustomersForUser.mockResolvedValue(responseWithEmptyEnterpriseCustomers);
+
+    renderWithRouter(
+      <EnterpriseCustomerRedirectWithContext initialAppState={initialAppState} />,
+    );
+
+    await waitFor(() => expect(fetchEnterpriseCustomersForUser).toHaveBeenCalledTimes(1));
+
+    // assert 404 page not found is shown
+    expect(screen.getByText('404'));
+  });
+
+  test('redirects to Enterprise Customer when user is linked to an individual Enterprise Customer', async () => {
+    fetchEnterpriseCustomersForUser.mockResolvedValue(responseWithIndividualEnterpriseCustomer);
+
+    const initialState = {
+      ...initialAppState,
+      authenticatedUser: {
+        ...initialAppState.authenticatedUser,
+        roles: [`enterprise_learner:${TEST_ENTERPRISES[0].uuid}`],
+      },
+    };
+
+    const Component = <EnterpriseCustomerRedirectWithContext initialAppState={initialState} />;
+    const { history } = renderWithRouter(Component, {
+      route: '/',
+    });
+
+    await waitFor(() => expect(fetchEnterpriseCustomersForUser).toHaveBeenCalledTimes(1));
+
+    expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISES[0].slug}`);
+  });
+
+  test('redirects to Enterprise Customer when user is linked to 2+ Enterprise Customers', async () => {
+    fetchEnterpriseCustomersForUser.mockResolvedValue(responseWithSeveralEnterpriseCustomers);
+
+    const initialState = {
+      ...initialAppState,
+      authenticatedUser: {
+        ...initialAppState.authenticatedUser,
+        roles: [
+          `enterprise_learner:${TEST_ENTERPRISES[1].uuid}`,
+          `enterprise_learner:${TEST_ENTERPRISES[0].uuid}`,
+        ],
+      },
+    };
+
+    const Component = <EnterpriseCustomerRedirectWithContext initialAppState={initialState} />;
+    const { history } = renderWithRouter(Component, {
+      route: '/',
+    });
+
+    await waitFor(() => expect(fetchEnterpriseCustomersForUser).toHaveBeenCalledTimes(1));
+
+    expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISES[1].slug}`);
+  });
+});

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -1,15 +1,15 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
-import { identify } from 'react-fullstory';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { AppContext, ErrorPage } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/config';
+import { Container } from '@edx/paragon';
 
 import { LoadingSpinner } from '../loading-spinner';
 import NotFoundPage from '../NotFoundPage';
 
-import { isDefined, isDefinedAndNull, isDefinedAndNotNull } from '../../utils/common';
+import { isDefined, isDefinedAndNull } from '../../utils/common';
 import {
   useEnterpriseCustomerConfig,
   useEnterpriseCustomerSubscriptionPlan,
@@ -18,26 +18,17 @@ import {
 export default function EnterprisePage({ children }) {
   const { enterpriseSlug } = useParams();
   const [enterpriseConfig, fetchError] = useEnterpriseCustomerConfig(enterpriseSlug);
-  const subscriptionPlan = useEnterpriseCustomerSubscriptionPlan(enterpriseConfig);
+  const subscriptionPlan = useEnterpriseCustomerSubscriptionPlan(enterpriseConfig?.uuid);
 
   const user = getAuthenticatedUser();
-  const { userId, profileImage } = user;
-
-  useEffect(
-    () => {
-      if (isDefinedAndNotNull(userId)) {
-        identify(userId);
-      }
-    },
-    [userId],
-  );
+  const { profileImage } = user;
 
   // Render the app as loading while waiting on the configuration or additional user metadata
-  if (!isDefined(enterpriseConfig) || !isDefined(subscriptionPlan) || !isDefined(profileImage)) {
+  if (!isDefined([enterpriseConfig, subscriptionPlan, profileImage])) {
     return (
-      <div className="container-fluid py-5">
+      <Container className="py-5">
         <LoadingSpinner screenReaderText="loading organization details" />
-      </div>
+      </Container>
     );
   }
 

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -4,10 +4,9 @@ import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import colors from '../../../colors.scss';
 import {
-  fetchEnterpriseCustomerConfig,
+  fetchEnterpriseCustomerConfigForSlug,
   fetchEnterpriseCustomerSubscriptionPlan,
 } from './service';
-import { isDefinedAndNull } from '../../../utils/common';
 
 export const defaultPrimaryColor = colors?.primary;
 export const defaultSecondaryColor = colors?.info100;
@@ -29,7 +28,7 @@ export function useEnterpriseCustomerConfig(enterpriseSlug) {
   const [fetchError, setFetchError] = useState();
 
   useEffect(() => {
-    fetchEnterpriseCustomerConfig(enterpriseSlug)
+    fetchEnterpriseCustomerConfigForSlug(enterpriseSlug)
       .then((response) => {
         const { results } = camelCaseObject(response.data);
         const config = results.pop();
@@ -85,15 +84,12 @@ export function useEnterpriseCustomerConfig(enterpriseSlug) {
   return [enterpriseConfig, fetchError];
 }
 
-export function useEnterpriseCustomerSubscriptionPlan(enterpriseConfig) {
+export function useEnterpriseCustomerSubscriptionPlan(enterpriseUUID) {
   const [subscriptionPlan, setSubscriptionPlan] = useState();
 
   useEffect(() => {
-    if (isDefinedAndNull(enterpriseConfig)) {
-      setSubscriptionPlan(null);
-    }
-    if (enterpriseConfig && enterpriseConfig.uuid) {
-      fetchEnterpriseCustomerSubscriptionPlan(enterpriseConfig.uuid)
+    if (enterpriseUUID) {
+      fetchEnterpriseCustomerSubscriptionPlan(enterpriseUUID)
         .then((response) => {
           const { results } = camelCaseObject(response.data);
           const activePlans = results.filter(plan => plan.isActive);
@@ -107,8 +103,10 @@ export function useEnterpriseCustomerSubscriptionPlan(enterpriseConfig) {
           logError(new Error(error));
           setSubscriptionPlan(null);
         });
+    } else {
+      setSubscriptionPlan(null);
     }
-  }, [enterpriseConfig]);
+  }, [enterpriseUUID]);
 
   return subscriptionPlan;
 }

--- a/src/components/enterprise-page/data/service.js
+++ b/src/components/enterprise-page/data/service.js
@@ -2,7 +2,7 @@ import qs from 'query-string';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
-export function fetchEnterpriseCustomerConfig(slug) {
+export function fetchEnterpriseCustomerConfigForSlug(slug) {
   const config = getConfig();
   const url = `${config.LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/?slug=${slug}`;
   const httpClient = getAuthenticatedHttpClient({

--- a/src/components/enterprise-page/data/tests/customerConfig.test.js
+++ b/src/components/enterprise-page/data/tests/customerConfig.test.js
@@ -6,7 +6,7 @@ import {
   defaultSecondaryColor,
   defaultTertiaryColor,
 } from '../hooks';
-import { fetchEnterpriseCustomerConfig } from '../service';
+import { fetchEnterpriseCustomerConfigForSlug } from '../service';
 
 const TEST_ENTERPRISE_SLUG = 'test-enterprise';
 
@@ -68,7 +68,7 @@ const responseWithBrandingConfigNullValues = {
 
 describe('customer config with various states of branding_configuration', () => {
   test('null branding_configuration uses default values and does not fail', async () => {
-    fetchEnterpriseCustomerConfig.mockResolvedValue(responseWithNullBrandingConfig);
+    fetchEnterpriseCustomerConfigForSlug.mockResolvedValue(responseWithNullBrandingConfig);
 
     const { result, waitForNextUpdate } = renderHook(() => useEnterpriseCustomerConfig(TEST_ENTERPRISE_SLUG));
 
@@ -85,7 +85,7 @@ describe('customer config with various states of branding_configuration', () => 
   });
 
   test('null values for fields in branding_config uses defaults and does not fail', async () => {
-    fetchEnterpriseCustomerConfig.mockResolvedValue(responseWithBrandingConfigNullValues);
+    fetchEnterpriseCustomerConfigForSlug.mockResolvedValue(responseWithBrandingConfigNullValues);
 
     const { result, waitForNextUpdate } = renderHook(() => useEnterpriseCustomerConfig(TEST_ENTERPRISE_SLUG));
 
@@ -102,7 +102,7 @@ describe('customer config with various states of branding_configuration', () => 
   });
 
   test('valid branding_config results in correct values for logo and other branding settings', async () => {
-    fetchEnterpriseCustomerConfig.mockResolvedValue(responseWithBrandingConfig);
+    fetchEnterpriseCustomerConfigForSlug.mockResolvedValue(responseWithBrandingConfig);
 
     const { result, waitForNextUpdate } = renderHook(() => useEnterpriseCustomerConfig(TEST_ENTERPRISE_SLUG));
 

--- a/src/components/enterprise-user-subsidy/UserSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidy.jsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { AppContext } from '@edx/frontend-platform/react';
+import { Container } from '@edx/paragon';
 
 import { LoadingSpinner } from '../loading-spinner';
 
@@ -22,7 +23,7 @@ const UserSubsidy = ({ children }) => {
     [isLoadingLicense, isLoadingOffers],
   );
 
-  const value = useMemo(
+  const contextValue = useMemo(
     () => {
       let hasAccessToPortal = true;
 
@@ -44,15 +45,15 @@ const UserSubsidy = ({ children }) => {
 
   if (isLoadingSubsidies) {
     return (
-      <div className="container-fluid py-5">
+      <Container className="py-5">
         <LoadingSpinner screenReaderText={LOADING_SCREEN_READER_TEXT} />
-      </div>
+      </Container>
     );
   }
   return (
     <>
       {/* Render the children so the rest of the page shows */}
-      <UserSubsidyContext.Provider value={value}>
+      <UserSubsidyContext.Provider value={contextValue}>
         {children}
       </UserSubsidyContext.Provider>
     </>

--- a/src/components/license-activation/LicenseActivation.jsx
+++ b/src/components/license-activation/LicenseActivation.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { AppContext } from '@edx/frontend-platform/react';
-import { StatusAlert } from '@edx/paragon';
+import { StatusAlert, Container } from '@edx/paragon';
 
 import { LoadingSpinner } from '../loading-spinner';
 import { useLicenseActivation } from './data/hooks';
@@ -34,7 +34,7 @@ export default function LicenseActivation() {
     return (
       <>
         <Helmet title={PAGE_TITLE} />
-        <div className="container-fluid mt-3">
+        <Container className="mt-3">
           <StatusAlert
             alertType="danger"
             dialog={(
@@ -47,7 +47,7 @@ export default function LicenseActivation() {
             dismissible={false}
             open
           />
-        </div>
+        </Container>
       </>
     );
   }
@@ -55,9 +55,9 @@ export default function LicenseActivation() {
   return (
     <>
       <Helmet title={PAGE_TITLE} />
-      <div className="container-fluid py-5">
+      <Container className="py-5">
         <LoadingSpinner screenReaderText={LOADING_MESSAGE} />
-      </div>
+      </Container>
     </>
   );
 }

--- a/src/components/search/SearchCourseCard.jsx
+++ b/src/components/search/SearchCourseCard.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import Skeleton from 'react-loading-skeleton';
 import { AppContext } from '@edx/frontend-platform/react';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
+import { Card } from '@edx/paragon';
 
 import { isDefinedAndNotNull } from '../../utils/common';
 
@@ -47,22 +48,23 @@ const SearchCourseCard = ({ hit, isLoading }) => {
 
   return (
     <div
-      className="discovery-card mb-4"
+      className="search-course-card mb-4"
       role="group"
       aria-label={course.title}
     >
       <Link to={linkToCourse}>
-        <div className="card">
+        <Card>
           {isLoading ? (
-            <Skeleton
-              className="card-img-top"
+            <Card.Img
+              as={Skeleton}
+              variant="top"
               duration={0}
               height={100}
               data-testid="card-img-loading"
             />
           ) : (
-            <img
-              className="card-img-top"
+            <Card.Img
+              variant="top"
               src={course.cardImageUrl}
               alt=""
             />
@@ -72,7 +74,7 @@ const SearchCourseCard = ({ hit, isLoading }) => {
               <Skeleton width={90} height={42} data-testid="partner-logo-loading" />
             </div>
           )}
-          {!isLoading && partnerDetails.primaryPartner && partnerDetails.showPartnerLogo && (
+          {(!isLoading && partnerDetails.primaryPartner && partnerDetails.showPartnerLogo) && (
             <div className="partner-logo-wrapper">
               <img
                 src={partnerDetails.primaryPartner.logoImageUrl}
@@ -81,8 +83,8 @@ const SearchCourseCard = ({ hit, isLoading }) => {
               />
             </div>
           )}
-          <div className="card-body py-4">
-            <h3 className="card-title h4 mb-1">
+          <Card.Body>
+            <Card.Title as="h4" className="card-title mb-1">
               {isLoading ? (
                 <Skeleton count={2} data-testid="course-title-loading" />
               ) : (
@@ -90,7 +92,7 @@ const SearchCourseCard = ({ hit, isLoading }) => {
                   {course.title}
                 </Truncate>
               )}
-            </h3>
+            </Card.Title>
             {isLoading ? (
               <Skeleton duration={0} data-testid="partner-name-loading" />
             ) : (
@@ -104,22 +106,22 @@ const SearchCourseCard = ({ hit, isLoading }) => {
                 )}
               </>
             )}
-          </div>
-          <div className="card-footer bg-white border-0 pt-0 pb-2">
+          </Card.Body>
+          <Card.Footer className="bg-white border-0 pt-0 pb-2">
             {isLoading ? (
               <Skeleton duration={0} data-testid="content-type-loading" />
             ) : (
               <span className="text-muted">Course</span>
             )}
-          </div>
-        </div>
+          </Card.Footer>
+        </Card>
       </Link>
     </div>
   );
 };
 
-const SkeletonCourseCard = () => (
-  <SearchCourseCard isLoading />
+const SkeletonCourseCard = (props) => (
+  <SearchCourseCard {...props} isLoading />
 );
 
 SearchCourseCard.Skeleton = SkeletonCourseCard;

--- a/src/components/search/SearchResults.jsx
+++ b/src/components/search/SearchResults.jsx
@@ -2,8 +2,9 @@ import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { connectStateResults, Hits } from 'react-instantsearch-dom';
 import Skeleton from 'react-loading-skeleton';
-
 import { useNbHitsFromSearchResults, SearchContext, SearchPagination } from '@edx/frontend-enterprise';
+import { Container, Row } from '@edx/paragon';
+
 import SearchCourseCard from './SearchCourseCard';
 import SearchNoResults from './SearchNoResults';
 import SearchError from './SearchError';
@@ -54,7 +55,7 @@ const SearchResults = ({
   );
 
   return (
-    <div className="search-results container-fluid my-5">
+    <Container className="search-results my-5">
       <>
         <div className="d-flex align-items-center mb-2">
           <h2 className="flex-grow-1 mb-0">
@@ -75,13 +76,13 @@ const SearchResults = ({
         {isSearchStalled && (
           <>
             <Skeleton className="lead mb-4" width={160} />
-            <div className="row">
+            <Row>
               {[...Array(NUM_RESULTS_PER_PAGE).keys()].map(resultNum => (
                 <div key={resultNum} className="skeleton-course-card">
                   <SearchCourseCard.Skeleton />
                 </div>
               ))}
-            </div>
+            </Row>
           </>
         )}
         {!isSearchStalled && nbHits > 0 && (
@@ -100,7 +101,7 @@ const SearchResults = ({
           <SearchError />
         )}
       </>
-    </div>
+    </Container>
   );
 };
 

--- a/src/components/search/styles/_SearchCourseCard.scss
+++ b/src/components/search/styles/_SearchCourseCard.scss
@@ -1,4 +1,4 @@
-.discovery-card {
+.search-course-card {
   a {
     color: $gray-700;
     text-decoration: none;

--- a/src/components/search/tests/SearchCourseCard.test.jsx
+++ b/src/components/search/tests/SearchCourseCard.test.jsx
@@ -58,7 +58,7 @@ describe('<SearchCourseCard />', () => {
     expect(screen.getByText(TEST_TITLE)).toBeInTheDocument();
     expect(screen.getByAltText(TEST_PARTNER.name)).toBeInTheDocument();
 
-    expect(container.querySelector('.discovery-card > a')).toHaveAttribute(
+    expect(container.querySelector('.search-course-card > a')).toHaveAttribute(
       'href',
       `/${TEST_ENTERPRISE_SLUG}/course/${TEST_COURSE_KEY}`,
     );

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -15,13 +15,27 @@ const AvatarDropdown = ({ showLabel }) => {
       <Dropdown.Toggle showLabel={showLabel} as={AvatarButton} src={profileImage.imageUrlMedium}>
         {username}
       </Dropdown.Toggle>
-      <Dropdown.Menu alignRight>
+      <Dropdown.Menu
+        style={{ maxWidth: 280 }}
+        alignRight
+      >
         <Dropdown.Header className="text-uppercase">Switch Dashboard</Dropdown.Header>
         <Dropdown.Item href={`${LMS_BASE_URL}/dashboard`}>Personal</Dropdown.Item>
-        <Dropdown.Item as={NavLink} to={enterpriseDashboardLink}>Enterprise</Dropdown.Item>
+        {/* TODO: support multiple enterprises! */}
+        <Dropdown.Item
+          as={NavLink}
+          to={enterpriseDashboardLink}
+          style={{
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {enterpriseConfig.name}
+        </Dropdown.Item>
         <Dropdown.Divider className="border-light" />
-        <Dropdown.Item href={`${LMS_BASE_URL}/u/${authenticatedUser.username}`}>My Profile</Dropdown.Item>
-        <Dropdown.Item href={`${LMS_BASE_URL}/account/settings`}>Account Settings</Dropdown.Item>
+        <Dropdown.Item href={`${LMS_BASE_URL}/u/${authenticatedUser.username}`}>My profile</Dropdown.Item>
+        <Dropdown.Item href={`${LMS_BASE_URL}/account/settings`}>Account settings</Dropdown.Item>
         <Dropdown.Item href="https://support.edx.org/hc/en-us">Help</Dropdown.Item>
         <Dropdown.Divider className="border-light" />
         <Dropdown.Item href={`${LOGOUT_URL}?next=${BASE_URL}${enterpriseDashboardLink}`}>Sign out</Dropdown.Item>

--- a/src/components/site-header/SiteHeader.jsx
+++ b/src/components/site-header/SiteHeader.jsx
@@ -3,21 +3,18 @@ import Responsive from 'react-responsive';
 import { Link, NavLink } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import { AppContext } from '@edx/frontend-platform/react';
+import { Menu as MenuIcon } from '@edx/paragon/icons';
+import { Container } from '@edx/paragon';
 import edXLogo from '@edx/brand/logo.svg';
 
 import { Menu, MenuTrigger, MenuContent } from './menu';
 import AvatarDropdown from './AvatarDropdown';
 
-import { ReactComponent as MenuIcon } from '../../assets/icons/menu.svg';
-
 export default function SiteHeader() {
   const { enterpriseConfig } = useContext(AppContext);
 
   const renderLogo = () => (
-    <Link
-      to={`/${enterpriseConfig.slug}`}
-      className="logo"
-    >
+    <Link to="/" className="logo">
       <img
         className="d-block"
         src={enterpriseConfig.branding.logo || edXLogo}
@@ -45,7 +42,7 @@ export default function SiteHeader() {
 
   const renderDesktopHeader = () => (
     <header className="site-header-desktop">
-      <div className="container-fluid">
+      <Container>
         <div className="nav-container position-relative d-flex align-items-center">
           {renderLogo()}
           <nav aria-label="Main" className="nav main-nav">
@@ -58,7 +55,7 @@ export default function SiteHeader() {
             <AvatarDropdown />
           </nav>
         </div>
-      </div>
+      </Container>
     </header>
   );
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -27,7 +27,6 @@ initialize({
     config: () => {
       mergeConfig({
         USE_API_CACHE: process.env.USE_API_CACHE || null,
-        FULLSTORY_ORG_ID: process.env.FULLSTORY_ORG_ID || null,
         ENTERPRISE_CATALOG_API_BASE_URL: process.env.ENTERPRISE_CATALOG_API_BASE_URL || null,
         LICENSE_MANAGER_URL: process.env.LICENSE_MANAGER_URL || null,
         ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID || null,


### PR DESCRIPTION
Ticket: [ENT-3349](https://openedx.atlassian.net/browse/ENT-3349)

Creates a new route to handle when learners go to https://enterprise.edx.org. Currently, we simply show a 404 not found but is confusing as some learners are going to this route, expecting to see their learner portal.

Additionally, by having a root route that intelligently redirects learners, ECS and other internal stakeholders will be able to provide a generic link to the Learner Portal without considering what slug the associated enterprise has.

This PR handles visits to this route by determining which enterprise customers a learner is linked to, and proceeding with the following checks:
1. If learner is linked to 0 customers, continue to show 404 not found.
1. If learner is linked to 1 customer, redirect to that enterprise's slug.
1. If learner is linked to 2+ customers, get the first "enterprise_learner" role and redirect to its associated enterprise slug.

_Note: In the case of a learner being linked to 2+ customers, the learner will first be prompted upon login/registration to "Select an organization" from their linked customers. Upon getting redirected back to https://enterprise.edx.org, their selected enterprise should be loaded. To change the learner's selection, they unfortunately must log out and back in again with what we have today._

This PR also consolidates our usage of `Container` now that the Paragon theme fixed up its container widths and removes our usage of FullStory now that edX no longer has an active plan with FullStory.