### PR TITLE
fix: resolve JS error when license loads before subs plan + move where subscriptionPlan lives in context

### DIFF
--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -12,11 +12,14 @@ import { MainContent, Sidebar } from '../layout';
 import { DashboardMainContent } from './main-content';
 import { DashboardSidebar } from './sidebar';
 import SubscriptionExpirationModal from './SubscriptionExpirationModal';
+import { UserSubsidyContext } from '../enterprise-user-subsidy';
 
 export const LICENCE_ACTIVATION_MESSAGE = 'Your license has been successfully activated.';
 
 export default function Dashboard() {
-  const { enterpriseConfig, subscriptionPlan } = useContext(AppContext);
+  const { enterpriseConfig } = useContext(AppContext);
+  const { subscriptionPlan } = useContext(UserSubsidyContext);
+
   const { state } = useLocation();
 
   const renderLicenseActivationSuccess = () => (

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react';
 import Cookies from 'universal-cookie';
+import moment from 'moment';
 import { Modal, MailtoLink } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
-
-import moment from 'moment';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+
+import { UserSubsidyContext } from '../enterprise-user-subsidy';
+
 import {
   SUBSCRIPTION_DAYS_REMAINING_SEVERE,
   SUBSCRIPTION_EXPIRED,
@@ -12,20 +14,16 @@ import {
 } from '../../config/constants';
 
 export const MODAL_DIALOG_CLASS_NAME = 'subscription-expiration';
-export const SUBSCRIPTION_EXPIRED_MODAL_TITLE = 'Your Subscription has Expired';
-export const SUBSCRIPTION_EXPIRING_MODAL_TITLE = 'Your Subscription is Expiring';
+export const SUBSCRIPTION_EXPIRED_MODAL_TITLE = 'Your subscription has expired';
+export const SUBSCRIPTION_EXPIRING_MODAL_TITLE = 'Your subscription is expiring';
 
 const SubscriptionExpirationModal = () => {
   const {
-    subscriptionPlan: {
-      daysUntilExpiration,
-      expirationDate,
-    },
-    enterpriseConfig: {
-      contactEmail,
-    },
+    enterpriseConfig: { contactEmail },
     config,
   } = useContext(AppContext);
+  const { subscriptionPlan } = useContext(UserSubsidyContext);
+  const { daysUntilExpiration, expirationDate } = subscriptionPlan;
 
   const renderTitle = () => {
     if (daysUntilExpiration > SUBSCRIPTION_EXPIRED) {

--- a/src/components/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/dashboard/sidebar/DashboardSidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -21,9 +21,9 @@ const DashboardSidebar = () => {
       contactEmail,
       slug,
     },
-    subscriptionPlan,
   } = useContext(AppContext);
   const {
+    subscriptionPlan,
     subscriptionLicense: userSubscriptionLicense,
     hasAccessToPortal,
     offers: { offersCount },
@@ -41,11 +41,22 @@ const DashboardSidebar = () => {
     return message;
   };
 
+  const shouldShowCatalogAccessCard = useMemo(
+    () => {
+      const hasSubscriptionPlan = !!subscriptionPlan;
+      const hasActivatedLicense = userSubscriptionLicense?.status === LICENSE_STATUS.ACTIVATED;
+      const hasOffers = offersCount > 0;
+
+      return (hasSubscriptionPlan && hasActivatedLicense) || hasOffers;
+    },
+    [subscriptionPlan, userSubscriptionLicense, offersCount],
+  );
+
   return (
     <div className="mt-3 mt-lg-0">
-      {(userSubscriptionLicense?.status === LICENSE_STATUS.ACTIVATED || offersCount > 0) && (
+      {shouldShowCatalogAccessCard && (
         <SidebarCard cardClassNames="border-primary border-brand-primary catalog-access-card mb-5">
-          {userSubscriptionLicense?.status === LICENSE_STATUS.ACTIVATED && (
+          {(subscriptionPlan && userSubscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) && (
             <SubscriptionSummaryCard
               subscriptionPlan={subscriptionPlan}
               className="mb-3"

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -30,6 +30,8 @@ const DashboardSidebarContext = ({
 
 describe('<DashboardSidebar />', () => {
   const defaultUserSubsidyState = {
+    subscriptionPlan: undefined,
+    subscriptionLicense: undefined,
     hasAccessToPortal: true,
     offers: {
       offers: [],
@@ -41,15 +43,12 @@ describe('<DashboardSidebar />', () => {
     enterpriseConfig: { contactEmail: 'foo@foo.com' },
     name: 'Bears Inc.',
   };
-  const appStateWithSubscription = {
-    ...initialAppState,
+  const userSubsidyStateWithSubscription = {
+    ...defaultUserSubsidyState,
     subscriptionPlan: {
       daysUntilExpiration: 70,
       expirationDate: '2021-10-25',
     },
-  };
-  const userSubsidyStateWithSubscription = {
-    ...defaultUserSubsidyState,
     subscriptionLicense: {
       status: LICENSE_STATUS.ACTIVATED,
     },
@@ -82,7 +81,7 @@ describe('<DashboardSidebar />', () => {
   test('subscription summary card is displayed when subscription is available', () => {
     renderWithRouter(
       <DashboardSidebarContext
-        initialAppState={appStateWithSubscription}
+        initialAppState={initialAppState}
         initialUserSubsidyState={userSubsidyStateWithSubscription}
       >
         <DashboardSidebar />
@@ -101,11 +100,18 @@ describe('<DashboardSidebar />', () => {
     );
     expect(screen.queryByText(SUBSCRIPTION_SUMMARY_CARD_TITLE)).toBeFalsy();
   });
-  test('subscription summary card is not displayed when enterprise subscription is available but user subscription is not available', () => {
+  test('subscription summary card is not displayed when enterprise subscription is available but user license is not available', () => {
     renderWithRouter(
       <DashboardSidebarContext
-        initialAppState={appStateWithSubscription}
-        initialUserSubsidyState={defaultUserSubsidyState}
+        initialAppState={initialAppState}
+        initialUserSubsidyState={{
+          ...defaultUserSubsidyState,
+          subscriptionPlan: {
+            daysUntilExpiration: 70,
+            isActive: true,
+            expirationDate: '2021-10-25',
+          },
+        }}
       >
         <DashboardSidebar />
       </DashboardSidebarContext>,

--- a/src/components/dashboard/tests/Dashboard.test.jsx
+++ b/src/components/dashboard/tests/Dashboard.test.jsx
@@ -68,10 +68,6 @@ describe('<Dashboard />', () => {
     enterpriseConfig: {
       name: 'BearsRUs',
     },
-    subscriptionPlan: {
-      expirationDate: '2020-10-25',
-      daysUntilExpiration: 365,
-    },
     config: {
       LMS_BASE_URL: process.env.LMS_BASE_URL,
     },
@@ -113,6 +109,10 @@ describe('<Dashboard />', () => {
       containsContentItems: true,
     },
   };
+  const mockSubscriptionPlan = {
+    expirationDate: '2020-10-25',
+    daysUntilExpiration: 365,
+  };
 
   afterAll(() => {
     jest.restoreAllMocks();
@@ -148,17 +148,17 @@ describe('<Dashboard />', () => {
   });
 
   it('renders the subscription expiration warning modal when 60 >= daysUntilExpiration > 0', () => {
-    const expiringSubscriptionAppState = {
-      ...initialAppState,
+    const expiringSubscriptionUserSubsidyState = {
+      ...initialUserSubsidyState,
       subscriptionPlan: {
-        ...initialAppState.subscriptionPlan,
+        ...mockSubscriptionPlan,
         daysUntilExpiration: 60,
       },
     };
     renderWithRouter(
       <DashboardWithContext
-        initialAppState={expiringSubscriptionAppState}
-        initialUserSubsidyState={initialUserSubsidyState}
+        initialAppState={initialAppState}
+        initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
         initialCourseState={initialCourseState}
       />,
     );
@@ -167,17 +167,17 @@ describe('<Dashboard />', () => {
   });
 
   it('renders the subscription expired modal when 0 >= daysUntilExpiration', () => {
-    const expiringSubscriptionAppState = {
-      ...initialAppState,
+    const expiringSubscriptionUserSubsidyState = {
+      ...initialUserSubsidyState,
       subscriptionPlan: {
-        ...initialAppState.subscriptionPlan,
+        ...mockSubscriptionPlan,
         daysUntilExpiration: 0,
       },
     };
     renderWithRouter(
       <DashboardWithContext
-        initialAppState={expiringSubscriptionAppState}
-        initialUserSubsidyState={initialUserSubsidyState}
+        initialAppState={initialAppState}
+        initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
         initialCourseState={initialCourseState}
       />,
     );

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -12,19 +12,17 @@ import NotFoundPage from '../NotFoundPage';
 import { isDefined, isDefinedAndNull } from '../../utils/common';
 import {
   useEnterpriseCustomerConfig,
-  useEnterpriseCustomerSubscriptionPlan,
 } from './data/hooks';
 
 export default function EnterprisePage({ children }) {
   const { enterpriseSlug } = useParams();
   const [enterpriseConfig, fetchError] = useEnterpriseCustomerConfig(enterpriseSlug);
-  const subscriptionPlan = useEnterpriseCustomerSubscriptionPlan(enterpriseConfig?.uuid);
 
   const user = getAuthenticatedUser();
   const { profileImage } = user;
 
   // Render the app as loading while waiting on the configuration or additional user metadata
-  if (!isDefined([enterpriseConfig, subscriptionPlan, profileImage])) {
+  if (!isDefined([enterpriseConfig, profileImage])) {
     return (
       <Container className="py-5">
         <LoadingSpinner screenReaderText="loading organization details" />
@@ -53,7 +51,6 @@ export default function EnterprisePage({ children }) {
           },
         },
         enterpriseConfig,
-        subscriptionPlan,
       }}
     >
       {children}

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -3,10 +3,7 @@ import { logError, logInfo } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import colors from '../../../colors.scss';
-import {
-  fetchEnterpriseCustomerConfigForSlug,
-  fetchEnterpriseCustomerSubscriptionPlan,
-} from './service';
+import { fetchEnterpriseCustomerConfigForSlug } from './service';
 
 export const defaultPrimaryColor = colors?.primary;
 export const defaultSecondaryColor = colors?.info100;
@@ -82,31 +79,4 @@ export function useEnterpriseCustomerConfig(enterpriseSlug) {
   }, [enterpriseSlug]);
 
   return [enterpriseConfig, fetchError];
-}
-
-export function useEnterpriseCustomerSubscriptionPlan(enterpriseUUID) {
-  const [subscriptionPlan, setSubscriptionPlan] = useState();
-
-  useEffect(() => {
-    if (enterpriseUUID) {
-      fetchEnterpriseCustomerSubscriptionPlan(enterpriseUUID)
-        .then((response) => {
-          const { results } = camelCaseObject(response.data);
-          const activePlans = results.filter(plan => plan.isActive);
-          if (activePlans.length) {
-            setSubscriptionPlan(activePlans.pop());
-          } else {
-            setSubscriptionPlan(null);
-          }
-        })
-        .catch((error) => {
-          logError(new Error(error));
-          setSubscriptionPlan(null);
-        });
-    } else {
-      setSubscriptionPlan(null);
-    }
-  }, [enterpriseUUID]);
-
-  return subscriptionPlan;
 }

--- a/src/components/enterprise-page/data/service.js
+++ b/src/components/enterprise-page/data/service.js
@@ -1,22 +1,9 @@
-import qs from 'query-string';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
 export function fetchEnterpriseCustomerConfigForSlug(slug) {
   const config = getConfig();
   const url = `${config.LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/?slug=${slug}`;
-  const httpClient = getAuthenticatedHttpClient({
-    useCache: config.USE_API_CACHE,
-  });
-  return httpClient.get(url);
-}
-
-export function fetchEnterpriseCustomerSubscriptionPlan(enterpriseUuid) {
-  const queryParams = {
-    enterprise_customer_uuid: enterpriseUuid,
-  };
-  const config = getConfig();
-  const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-subscriptions/?${qs.stringify(queryParams)}`;
   const httpClient = getAuthenticatedHttpClient({
     useCache: config.USE_API_CACHE,
   });

--- a/src/components/enterprise-user-subsidy/UserSubsidyAlerts.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidyAlerts.jsx
@@ -5,8 +5,8 @@ import OffersAlert from './OffersAlert';
 import SubscriptionSubsidy from './SubscriptionSubsidy';
 
 const UserSubsidyAlerts = () => {
-  const { enterpriseConfig, subscriptionPlan } = useContext(AppContext);
-  const { subscriptionLicense, offers } = useContext(UserSubsidyContext);
+  const { enterpriseConfig } = useContext(AppContext);
+  const { subscriptionPlan, subscriptionLicense, offers } = useContext(UserSubsidyContext);
 
   return (
     <>

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -8,8 +8,39 @@ import { fetchOffers } from '../offers';
 import offersReducer, { initialOfferState } from '../offers/data/reducer';
 
 import { LICENSE_STATUS } from './constants';
-import { fetchSubscriptionLicensesForUser } from './service';
+import {
+  fetchEnterpriseCustomerSubscriptionPlan,
+  fetchSubscriptionLicensesForUser,
+} from './service';
 import { features } from '../../../config';
+
+export function useEnterpriseCustomerSubscriptionPlan(enterpriseUUID) {
+  const [subscriptionPlan, setSubscriptionPlan] = useState();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!enterpriseUUID) {
+      setSubscriptionPlan(null);
+      return;
+    }
+    fetchEnterpriseCustomerSubscriptionPlan(enterpriseUUID)
+      .then((response) => {
+        const { results } = camelCaseObject(response.data);
+        const activePlans = results.filter(plan => plan.isActive);
+        const activeSubscriptionPlan = activePlans.pop() || null;
+        setSubscriptionPlan(activeSubscriptionPlan);
+      })
+      .catch((error) => {
+        logError(new Error(error));
+        setSubscriptionPlan(null);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [enterpriseUUID]);
+
+  return [subscriptionPlan, isLoading];
+}
 
 export function useSubscriptionLicenseForUser(enterpriseId) {
   const [license, setLicense] = useState();

--- a/src/components/enterprise-user-subsidy/data/service.js
+++ b/src/components/enterprise-user-subsidy/data/service.js
@@ -1,8 +1,24 @@
+import qs from 'query-string';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
-export function fetchSubscriptionLicensesForUser(enterpriseUuid) {
+export function fetchEnterpriseCustomerSubscriptionPlan(enterpriseUUID) {
+  const queryParams = {
+    enterprise_customer_uuid: enterpriseUUID,
+  };
   const config = getConfig();
-  const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-licenses/?enterprise_customer_uuid=${enterpriseUuid}`;
+  const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-subscriptions/?${qs.stringify(queryParams)}`;
+  const httpClient = getAuthenticatedHttpClient({
+    useCache: config.USE_API_CACHE,
+  });
+  return httpClient.get(url);
+}
+
+export function fetchSubscriptionLicensesForUser(enterpriseUUID) {
+  const queryParams = {
+    enterprise_customer_uuid: enterpriseUUID,
+  };
+  const config = getConfig();
+  const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-licenses/?${qs.stringify(queryParams)}`;
   return getAuthenticatedHttpClient().get(url);
 }

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -17,8 +17,8 @@ import { IntegrationWarningModal } from '../integration-warning-modal';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 
 const Search = () => {
-  const { enterpriseConfig, subscriptionPlan } = useContext(AppContext);
-  const { offers: { offers } } = useContext(UserSubsidyContext);
+  const { enterpriseConfig } = useContext(AppContext);
+  const { subscriptionPlan, offers: { offers } } = useContext(UserSubsidyContext);
   const offerCatalogs = offers.map((offer) => offer.catalog);
   const { filters } = useDefaultSearchFilters({
     enterpriseConfig,


### PR DESCRIPTION
Noticed this JS error on stage, potentially related to some recent updates:

![image](https://user-images.githubusercontent.com/2828721/109087905-5ec84d00-76dc-11eb-964d-c81e9ab7b636.png)

This PR prevents the error from occurring and also moves `subscriptionPlan` from `AppContext` into `UserSubsidyContext`, and updated all the places where we previously expected `subscriptionPlan` in `AppContext`. The rationale for this change is to colocate where all subscriptions data (both subscription plan and subscription licenses) are fetched/stored.