### PR TITLE
ENT-4217: enrollmentUrl was sourced from incorrect place in two EnrollAction use cases

### DIFF
--- a/src/components/course/enrollment/EnrollAction.jsx
+++ b/src/components/course/enrollment/EnrollAction.jsx
@@ -59,9 +59,9 @@ const EnrollAction = ({
             />
           );
       case TO_VOUCHER_REDEEM:
-          return <ToVoucherRedeemPage enrollLabel={enrollLabel} />;
+          return <ToVoucherRedeemPage enrollmentUrl={enrollmentUrl} enrollLabel={enrollLabel} />;
       case TO_ECOM_BASKET:
-          return <ToEcomBasketPage enrollLabel={enrollLabel} />;
+          return <ToEcomBasketPage enrollmentUrl={enrollmentUrl} enrollLabel={enrollLabel} />;
       default: return null;
   }
 };

--- a/src/components/course/enrollment/components/ToEcomBasketPage.jsx
+++ b/src/components/course/enrollment/components/ToEcomBasketPage.jsx
@@ -10,10 +10,13 @@ import ToVoucherRedeemPage from './ToVoucherRedeemPage';
  * @param {Component} args.enrollLabel An EnrollLabel component
  * @returns {Component} Rendered enroll button with a enrollment modal behavior included.
  */
-const ToEcomBasketPage = ({ enrollLabel }) => (
-  <ToVoucherRedeemPage enrollLabel={enrollLabel} />
+const ToEcomBasketPage = ({ enrollLabel, enrollmentUrl }) => (
+  <ToVoucherRedeemPage enrollmentUrl={enrollmentUrl} enrollLabel={enrollLabel} />
 );
 
-ToEcomBasketPage.propTypes = { enrollLabel: PropTypes.node.isRequired };
+ToEcomBasketPage.propTypes = {
+  enrollLabel: PropTypes.node.isRequired,
+  enrollmentUrl: PropTypes.string.isRequired,
+};
 
 export default ToEcomBasketPage;

--- a/src/components/course/enrollment/components/ToVoucherRedeemPage.jsx
+++ b/src/components/course/enrollment/components/ToVoucherRedeemPage.jsx
@@ -7,8 +7,8 @@ import EnrollModal from '../../EnrollModal';
 import { enrollLinkClass } from '../constants';
 import { EnrollButtonCta } from '../common';
 
-const ToVoucherRedeemPage = ({ enrollLabel }) => {
-  const { courseHasOffer, offersCount, enrollmentUrl } = useSubsidyDataForCourse();
+const ToVoucherRedeemPage = ({ enrollLabel, enrollmentUrl }) => {
+  const { courseHasOffer, offersCount } = useSubsidyDataForCourse();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -28,5 +28,9 @@ const ToVoucherRedeemPage = ({ enrollLabel }) => {
     </>
   );
 };
-ToVoucherRedeemPage.propTypes = { enrollLabel: PropTypes.shape.isRequired };
+ToVoucherRedeemPage.propTypes = {
+  enrollLabel: PropTypes.shape.isRequired,
+  enrollmentUrl: PropTypes.string.isRequired,
+};
+
 export default ToVoucherRedeemPage;

--- a/src/components/course/enrollment/tests/EnrollAction.test.jsx
+++ b/src/components/course/enrollment/tests/EnrollAction.test.jsx
@@ -176,7 +176,15 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
     expect(screen.getByText(enrollLabelText).closest('button')).toBeInTheDocument();
     expect(screen.getByText(enrollLabelText).closest('a')).not.toBeInTheDocument();
     const regex = new RegExp().compile(ENROLL_MODAL_TEXT_NO_OFFERS);
+    screen.debug();
     expect(screen.getByText(regex)).toBeInTheDocument();
+
+    const PAYMENT_TEXT = 'Continue to payment';
+    // also check url is rendered in the modal correctly
+    expect(screen.queryByText(PAYMENT_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(PAYMENT_TEXT).closest('a')).toBeInTheDocument();
+    const enrollmentUrlRendered = screen.getByText(PAYMENT_TEXT).closest('a').href;
+    expect(enrollmentUrlRendered).toBe(`${ `${enrollmentUrl }/` }`); // don't see what adds the trailing slash
   });
   test('ecom basket link rendered when enrollmentType is TO_VOUCHER_REDEEM', () => {
     // offers must exist, subscriptionlicense must not, catalogs list must exist.
@@ -217,5 +225,12 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
     expect(screen.getByText(enrollLabelText).closest('a')).not.toBeInTheDocument();
     const regex = new RegExp().compile(createUseVoucherText(1));
     expect(screen.getByText(regex)).toBeInTheDocument();
+
+    const PAYMENT_TEXT = 'Enroll in course';
+    // also check url is rendered in the modal correctly
+    expect(screen.queryByText(PAYMENT_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(PAYMENT_TEXT).closest('a')).toBeInTheDocument();
+    const enrollmentUrlRendered = screen.getByText(PAYMENT_TEXT).closest('a').href;
+    expect(enrollmentUrlRendered).toBe(`${ `${enrollmentUrl }/` }`); // don't see what adds the trailing slash
   });
 });

--- a/src/components/course/enrollment/tests/EnrollAction.test.jsx
+++ b/src/components/course/enrollment/tests/EnrollAction.test.jsx
@@ -176,7 +176,6 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
     expect(screen.getByText(enrollLabelText).closest('button')).toBeInTheDocument();
     expect(screen.getByText(enrollLabelText).closest('a')).not.toBeInTheDocument();
     const regex = new RegExp().compile(ENROLL_MODAL_TEXT_NO_OFFERS);
-    screen.debug();
     expect(screen.getByText(regex)).toBeInTheDocument();
 
     const PAYMENT_TEXT = 'Continue to payment';

--- a/src/components/course/enrollment/tests/EnrollAction.test.jsx
+++ b/src/components/course/enrollment/tests/EnrollAction.test.jsx
@@ -133,9 +133,16 @@ describe('scenarios when use is not enrolled and is not eligible to', () => {
 });
 
 describe('scenarios user not yet enrolled, but eligible to enroll', () => {
+  const A_COURSE_WITH_NO_SUBSCRIPTIONS = {
+    ...selfPacedCourseWithLicenseSubsidy,
+    catalog: {
+      catalogList: ['a-catalog'],
+    },
+    userSubsidyApplicableToCourse: null,
+  };
+  const enrollmentUrl = 'http://test';
+  const enrollLabelText = 'disabled text!';
   test('datasharing consent link rendered when enrollmentType is TO_DATASHARING_CONSENT', () => {
-    const enrollLabelText = 'disabled text!';
-    const enrollmentUrl = 'http://test';
     const enrollAction = (
       <EnrollAction
         enrollmentType={TO_DATASHARING_CONSENT}
@@ -150,9 +157,7 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
     const actualUrl = screen.getByText(enrollLabelText).closest('a').href;
     expect(actualUrl).toContain(`${enrollmentUrl}`);
   });
-  test('ecom basket link rendered when enrollmentType is TO_ECOM_BASKET', () => {
-    const enrollLabelText = 'some text!';
-    const enrollmentUrl = 'http://test';
+  test('no vouchers text is rendered when enrollmentType is TO_ECOM_BASKET', () => {
     const enrollAction = (
       <EnrollAction
         enrollmentType={TO_ECOM_BASKET}
@@ -177,7 +182,25 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
     expect(screen.getByText(enrollLabelText).closest('a')).not.toBeInTheDocument();
     const regex = new RegExp().compile(ENROLL_MODAL_TEXT_NO_OFFERS);
     expect(screen.getByText(regex)).toBeInTheDocument();
-
+  });
+  test('ecom basket link rendered when enrollmentType is TO_ECOM_BASKET', () => {
+    const enrollAction = (
+      <EnrollAction
+        enrollmentType={TO_ECOM_BASKET}
+        enrollLabel={<EnrollLabel enrollLabelText={enrollLabelText} />}
+        enrollmentUrl={enrollmentUrl}
+        subscriptionLicense={subscriptionLicense}
+      />
+    );
+    // this initialUserSubsidyState is passed as a value to the UserSubsidyContext.provider
+    // which is then used by a hook to check if the user has a license
+    renderEnrollAction({
+      enrollAction,
+      initialUserSubsidyState: {
+        subscriptionLicense,
+        offers: { offers: [] },
+      },
+    });
     const PAYMENT_TEXT = 'Continue to payment';
     // also check url is rendered in the modal correctly
     expect(screen.queryByText(PAYMENT_TEXT)).toBeInTheDocument();
@@ -185,11 +208,9 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
     const enrollmentUrlRendered = screen.getByText(PAYMENT_TEXT).closest('a').href;
     expect(enrollmentUrlRendered).toBe(`${ `${enrollmentUrl }/` }`); // don't see what adds the trailing slash
   });
-  test('ecom basket link rendered when enrollmentType is TO_VOUCHER_REDEEM', () => {
+  test('enroll text with voucher count is rendered when enrollmentType is TO_VOUCHER_REDEEM', () => {
     // offers must exist, subscriptionlicense must not, catalogs list must exist.
     // a catalog in the cataloglist must match the one in the offer (see `findOffersForCourse()`)
-    const enrollLabelText = 'some text!';
-    const enrollmentUrl = 'http://test';
     const enrollAction = (
       <EnrollAction
         enrollmentType={TO_VOUCHER_REDEEM}
@@ -197,13 +218,6 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
         enrollmentUrl={enrollmentUrl}
       />
     );
-    const A_COURSE_WITH_NO_SUBSCRIPTIONS = {
-      ...selfPacedCourseWithLicenseSubsidy,
-      catalog: {
-        catalogList: ['a-catalog'],
-      },
-      userSubsidyApplicableToCourse: null,
-    };
     // this initialUserSubsidyState is passed as a value to the UserSubsidyContext.provider
     // which is then used by a hook to check if the user has a license
     renderEnrollAction({
@@ -224,7 +238,32 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
     expect(screen.getByText(enrollLabelText).closest('a')).not.toBeInTheDocument();
     const regex = new RegExp().compile(createUseVoucherText(1));
     expect(screen.getByText(regex)).toBeInTheDocument();
+  });
+  test('ecom basket link rendered in modal when enrollmentType is TO_VOUCHER_REDEEM', () => {
+    // offers must exist, subscriptionlicense must not, catalogs list must exist.
+    // a catalog in the cataloglist must match the one in the offer (see `findOffersForCourse()`)
+    const enrollAction = (
+      <EnrollAction
+        enrollmentType={TO_VOUCHER_REDEEM}
+        enrollLabel={<EnrollLabel enrollLabelText={enrollLabelText} />}
+        enrollmentUrl={enrollmentUrl}
+      />
+    );
+    // this initialUserSubsidyState is passed as a value to the UserSubsidyContext.provider
+    // which is then used by a hook to check if the user has a license
+    renderEnrollAction({
+      enrollAction,
+      courseInitState: A_COURSE_WITH_NO_SUBSCRIPTIONS,
+      initialUserSubsidyState: {
+        subscriptionLicense: null,
+        offers: {
+          offers: [A_100_PERCENT_OFFER],
+          offersCount: 1,
+        },
+      },
+    });
 
+    // ensure button is rendered with label text indicating voucher count
     const PAYMENT_TEXT = 'Enroll in course';
     // also check url is rendered in the modal correctly
     expect(screen.queryByText(PAYMENT_TEXT)).toBeInTheDocument();


### PR DESCRIPTION
Use cases broken were: to_ecom_basket, and to_voucher_redeem_page

__Why bug was inserted?__
these were getting enrollmentUrl from useSubsidyDataForCourse() instead of the passed in enrollmentUrl prop which has been resolved by prior business logic in a hook

Was introduced in https://github.com/edx/frontend-app-learner-portal-enterprise/pull/198/files

__Why not detected?__
There was no automated test capturing the rendered url inside the modals in these cases.

Fix includes:
* fix
* test cases that are confirmed/verified to fail when I re introduce the code bug
