### PR TITLE
Move useDefaultSearchFilters back to learner portal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1388,32 +1388,9 @@
       }
     },
     "@edx/frontend-enterprise": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise/-/frontend-enterprise-4.6.3.tgz",
-      "integrity": "sha512-m5X9/MULnFZAstMLVGvQTGNkCVf161WgaLALdDOCCj3FAPu2gMe09s+Ve270LOO7aQkgnlDOMEUl0nth7Jl/5Q==",
-      "requires": {
-        "@fortawesome/free-solid-svg-icons": "^5.8.1",
-        "@fortawesome/react-fontawesome": "^0.1.4",
-        "classnames": "^2.2.5",
-        "query-string": "^5.1.1",
-        "react-instantsearch-dom": "^6.8.3",
-        "react-loading-skeleton": "^2.1.1"
-      },
-      "dependencies": {
-        "react-instantsearch-dom": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.10.0.tgz",
-          "integrity": "sha512-t1IGn1i4btp9a8wNNV/OCYwfJwCx5CuCP6WNwBxYY1QeL27RKGaWPxvz6FjfRFCfrOvD2556STyvVriyGhDoeg==",
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "algoliasearch-helper": "^3.4.3",
-            "classnames": "^2.2.5",
-            "prop-types": "^15.6.2",
-            "react-fast-compare": "^3.0.0",
-            "react-instantsearch-core": "^6.10.0"
-          }
-        }
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise/-/frontend-enterprise-5.0.2.tgz",
+      "integrity": "sha512-bBL6tU8ht1s/zV2DmXV49jAAF9feaUaXu2M/07rBmRIaN9rNjqsHhBSnFhsJLSFp7V3V4AD34zBmyIhjHRg8AA=="
     },
     "@edx/frontend-platform": {
       "version": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.0",
-    "@edx/frontend-enterprise": "4.6.3",
+    "@edx/frontend-enterprise": "5.0.2",
     "@edx/frontend-platform": "1.8.2",
     "@edx/paragon": "13.12.1",
     "@fortawesome/fontawesome-svg-core": "1.2.32",

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -6,8 +6,8 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/config';
 import {
   SearchHeader,
-  useDefaultSearchFilters,
 } from '@edx/frontend-enterprise';
+import { useDefaultSearchFilters } from './data/hooks';
 
 import { NUM_RESULTS_PER_PAGE } from './constants';
 import SearchResults from './SearchResults';
@@ -17,11 +17,12 @@ import { UserSubsidyContext } from '../enterprise-user-subsidy';
 
 const Search = () => {
   const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionPlan, offers: { offers } } = useContext(UserSubsidyContext);
+  const { subscriptionPlan, subscriptionLicense, offers: { offers } } = useContext(UserSubsidyContext);
   const offerCatalogs = offers.map((offer) => offer.catalog);
   const { filters } = useDefaultSearchFilters({
     enterpriseConfig,
     subscriptionPlan,
+    subscriptionLicense,
     offerCatalogs,
   });
 

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -1,0 +1,52 @@
+import { useContext, useMemo, useEffect } from 'react';
+import {
+  SearchContext, getCatalogString, SHOW_ALL_NAME, setRefinementAction,
+} from '@edx/frontend-enterprise';
+import { features } from '../../../config';
+import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
+
+export const useDefaultSearchFilters = ({
+  enterpriseConfig, subscriptionPlan, subscriptionLicense, offerCatalogs = [],
+}) => {
+  // default to showing all catalogs
+  const { refinementsFromQueryParams, dispatch } = useContext(SearchContext);
+
+  useEffect(() => {
+    // if the user has no subscriptions or offers, we default to showing all catalogs
+    if (!(subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) && offerCatalogs.length < 1) {
+      dispatch(setRefinementAction(SHOW_ALL_NAME, 1));
+    }
+  }, [subscriptionLicense?.status, offerCatalogs.length]);
+
+  const filters = useMemo(
+    () => {
+      if (refinementsFromQueryParams[SHOW_ALL_NAME]) {
+        // show all enterprise catalogs
+        return `enterprise_customer_uuids:${enterpriseConfig.uuid}`;
+      }
+      // if there's a subscriptionPlan, filter results by the subscription catalog
+      // and any catalogs for which the user has vouchers
+      if (subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) {
+        if (features.ENROLL_WITH_CODES && offerCatalogs.length > 0) {
+          const catalogs = [subscriptionPlan.enterpriseCatalogUuid, ...offerCatalogs];
+          return getCatalogString(catalogs);
+        }
+        return `enterprise_catalog_uuids:${subscriptionPlan.enterpriseCatalogUuid}`;
+      }
+      if (features.ENROLL_WITH_CODES && offerCatalogs.length > 0) {
+        // shows catalogs for which a user has 100% vouchers
+        return getCatalogString(offerCatalogs);
+      }
+      return `enterprise_customer_uuids:${enterpriseConfig.uuid}`;
+    },
+    [
+      enterpriseConfig,
+      subscriptionPlan,
+      offerCatalogs,
+      refinementsFromQueryParams[SHOW_ALL_NAME],
+      subscriptionLicense?.status,
+    ],
+  );
+
+  return { filters };
+};

--- a/src/components/search/data/tests/hooks.test.jsx
+++ b/src/components/search/data/tests/hooks.test.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import '@testing-library/jest-dom/extend-expect';
+import {
+  getCatalogString, SearchContext, SearchData, SHOW_ALL_NAME,
+} from '@edx/frontend-enterprise';
+import {
+  useDefaultSearchFilters,
+} from '../hooks';
+import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
+
+const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
+const TEST_SUBSCRIPTION_CATALOG_UUID = 'test-subscription-catalog-uuid';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    search: '?q=test%20query&subjects=Computer%20Science,Communication&availability=Upcoming&ignore=true',
+  }),
+  useHistory: () => ({ push: jest.fn }),
+}));
+jest.mock('../../../../config', () => ({
+  features: { ENROLL_WITH_CODES: true },
+}));
+
+const SearchWrapper = (value) => ({ children }) => (
+  <SearchContext.Provider value={value}>{children}</SearchContext.Provider>);
+
+describe('useDefaultSearchFilters hook', () => {
+  const enterpriseConfig = { uuid: TEST_ENTERPRISE_UUID };
+  const subscriptionPlan = { enterpriseCatalogUuid: TEST_SUBSCRIPTION_CATALOG_UUID };
+  const validSubscriptionLicense = { status: LICENSE_STATUS.ACTIVATED };
+  const invalidSubscriptionLicense = { status: LICENSE_STATUS.ASSIGNED };
+  const refinementsFromQueryParamsShowAll = { refinementsFromQueryParams: { [SHOW_ALL_NAME]: 1 } };
+  describe('no catalogs', () => {
+    test('no subscription: returns enterprise customer uuid as filter', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig,
+      }), { wrapper: SearchData });
+      const { filters } = result.current;
+      expect(filters).toBeDefined();
+      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+    });
+
+    test('with valid subscription: returns subscription catalog uuid as filter', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig, subscriptionPlan, subscriptionLicense: validSubscriptionLicense,
+      }), { wrapper: SearchData });
+      const { filters } = result.current;
+      expect(filters).toBeDefined();
+      expect(filters).toEqual(`enterprise_catalog_uuids:${TEST_SUBSCRIPTION_CATALOG_UUID}`);
+    });
+
+    test('with invalid subscription: returns enterprise customer uuid as a filter', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig,
+        subscriptionPlan,
+        subscriptionLicense: invalidSubscriptionLicense,
+      }), { wrapper: SearchData });
+      const { filters } = result.current;
+      expect(filters).toBeDefined();
+      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+    });
+    test('with valid subscription and showAllCatalogs: returns subscription and all enterprise catalogs', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig,
+        subscriptionPlan,
+        subscriptionLicense: validSubscriptionLicense,
+      }), { wrapper: SearchWrapper({ ...refinementsFromQueryParamsShowAll }) });
+
+      const { filters } = result.current;
+      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+    });
+  });
+  describe('with catalogs', () => {
+    const offerCatalogs = ['catalog1', 'catalog2'];
+    test('with valid subscription: returns subscription and offers', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig,
+        subscriptionPlan,
+        subscriptionLicense: validSubscriptionLicense,
+        offerCatalogs,
+      }), { wrapper: SearchData });
+      const { filters } = result.current;
+      expect(filters).toBeDefined();
+      expect(filters)
+        .toEqual(`enterprise_catalog_uuids:${TEST_SUBSCRIPTION_CATALOG_UUID} OR ${getCatalogString(offerCatalogs)}`);
+    });
+    test('with invalid subscription: returns offer catalogs', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig,
+        subscriptionPlan,
+        subscriptionLicense: invalidSubscriptionLicense,
+        offerCatalogs,
+      }), { wrapper: SearchData });
+      const { filters } = result.current;
+      expect(filters).toBeDefined();
+      expect(filters)
+        .toEqual(getCatalogString(offerCatalogs));
+    });
+    test('no subscription: returns only offers', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig,
+        subscriptionPlan: null,
+        offerCatalogs,
+      }), { wrapper: SearchData });
+      const { filters } = result.current;
+      expect(filters).toBeDefined();
+      expect(filters).toEqual(getCatalogString(offerCatalogs));
+    });
+    test('with showAllCatalogs: returns all enterprise catalgos', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig,
+        subscriptionPlan: null,
+        offerCatalogs,
+      }), { wrapper: SearchWrapper({ ...refinementsFromQueryParamsShowAll }) });
+      const { filters } = result.current;
+      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+    });
+    test('with valid subscription and show all: returns all enterprise catalogs', () => {
+      const { result } = renderHook(() => useDefaultSearchFilters({
+        enterpriseConfig,
+        subscriptionPlan,
+        subscriptionLicense: validSubscriptionLicense,
+        offerCatalogs,
+      }), { wrapper: SearchWrapper({ ...refinementsFromQueryParamsShowAll }) });
+      const { filters } = result.current;
+      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+    });
+  });
+});


### PR DESCRIPTION
This function is only relevant to this repo
Uses the user's license instead of the subscription plan to determine if user has a license