### PR TITLE
feat: adds useCache prop to AuthenticatedPage, removes the use of cac…

### DIFF
--- a/src/components/app/AuthenticatedPage.jsx
+++ b/src/components/app/AuthenticatedPage.jsx
@@ -6,10 +6,10 @@ import { EnterpriseBanner } from '../enterprise-banner';
 import { Layout } from '../layout';
 import { LoginRedirect } from '../login-redirect';
 
-export default function AuthenticatedPage({ children }) {
+export default function AuthenticatedPage({ children, useCache }) {
   return (
     <LoginRedirect>
-      <EnterprisePage>
+      <EnterprisePage useCache={useCache}>
         <Layout>
           <EnterpriseBanner />
           {children}
@@ -21,4 +21,9 @@ export default function AuthenticatedPage({ children }) {
 
 AuthenticatedPage.propTypes = {
   children: PropTypes.node.isRequired,
+  useCache: PropTypes.bool,
+};
+
+AuthenticatedPage.defaultProps = {
+  useCache: true,
 };

--- a/src/components/app/AuthenticatedPage.jsx
+++ b/src/components/app/AuthenticatedPage.jsx
@@ -6,10 +6,10 @@ import { EnterpriseBanner } from '../enterprise-banner';
 import { Layout } from '../layout';
 import { LoginRedirect } from '../login-redirect';
 
-export default function AuthenticatedPage({ children, useCache }) {
+export default function AuthenticatedPage({ children, useEnterpriseConfigCache }) {
   return (
     <LoginRedirect>
-      <EnterprisePage useCache={useCache}>
+      <EnterprisePage useEnterpriseConfigCache={useEnterpriseConfigCache}>
         <Layout>
           <EnterpriseBanner />
           {children}
@@ -21,9 +21,9 @@ export default function AuthenticatedPage({ children, useCache }) {
 
 AuthenticatedPage.propTypes = {
   children: PropTypes.node.isRequired,
-  useCache: PropTypes.bool,
+  useEnterpriseConfigCache: PropTypes.bool,
 };
 
 AuthenticatedPage.defaultProps = {
-  useCache: true,
+  useEnterpriseConfigCache: true,
 };

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -14,9 +14,9 @@ import {
   useEnterpriseCustomerConfig,
 } from './data/hooks';
 
-export default function EnterprisePage({ children }) {
+export default function EnterprisePage({ children, useCache }) {
   const { enterpriseSlug } = useParams();
-  const [enterpriseConfig, fetchError] = useEnterpriseCustomerConfig(enterpriseSlug);
+  const [enterpriseConfig, fetchError] = useEnterpriseCustomerConfig(enterpriseSlug, useCache);
 
   const user = getAuthenticatedUser();
   const { profileImage } = user;
@@ -60,4 +60,9 @@ export default function EnterprisePage({ children }) {
 
 EnterprisePage.propTypes = {
   children: PropTypes.node.isRequired,
+  useCache: PropTypes.bool,
+};
+
+EnterprisePage.defaultProps = {
+  useCache: true,
 };

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -14,9 +14,9 @@ import {
   useEnterpriseCustomerConfig,
 } from './data/hooks';
 
-export default function EnterprisePage({ children, useCache }) {
+export default function EnterprisePage({ children, useEnterpriseConfigCache }) {
   const { enterpriseSlug } = useParams();
-  const [enterpriseConfig, fetchError] = useEnterpriseCustomerConfig(enterpriseSlug, useCache);
+  const [enterpriseConfig, fetchError] = useEnterpriseCustomerConfig(enterpriseSlug, useEnterpriseConfigCache);
 
   const user = getAuthenticatedUser();
   const { profileImage } = user;
@@ -60,9 +60,9 @@ export default function EnterprisePage({ children, useCache }) {
 
 EnterprisePage.propTypes = {
   children: PropTypes.node.isRequired,
-  useCache: PropTypes.bool,
+  useEnterpriseConfigCache: PropTypes.bool,
 };
 
 EnterprisePage.defaultProps = {
-  useCache: true,
+  useEnterpriseConfigCache: true,
 };

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -18,14 +18,15 @@ const defaultBrandingConfig = {
 
 /**
  * @param {string} [enterpriseSlug] enterprise slug.
+ * @param {boolean} [useCache] indicates whether cache should be used
  * @returns {object} EnterpriseConfig
  */
-export function useEnterpriseCustomerConfig(enterpriseSlug) {
+export function useEnterpriseCustomerConfig(enterpriseSlug, useCache = true) {
   const [enterpriseConfig, setEnterpriseConfig] = useState();
   const [fetchError, setFetchError] = useState();
 
   useEffect(() => {
-    fetchEnterpriseCustomerConfigForSlug(enterpriseSlug)
+    fetchEnterpriseCustomerConfigForSlug(enterpriseSlug, useCache)
       .then((response) => {
         const { results } = camelCaseObject(response.data);
         const config = results.pop();

--- a/src/components/enterprise-page/data/service.js
+++ b/src/components/enterprise-page/data/service.js
@@ -1,11 +1,11 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
-export function fetchEnterpriseCustomerConfigForSlug(slug) {
+export function fetchEnterpriseCustomerConfigForSlug(slug, useCache = true) {
   const config = getConfig();
   const url = `${config.LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/?slug=${slug}`;
   const httpClient = getAuthenticatedHttpClient({
-    useCache: config.USE_API_CACHE,
+    useCache: useCache && config.USE_API_CACHE,
   });
   return httpClient.get(url);
 }

--- a/src/components/license-activation/LicenseActivationPage.jsx
+++ b/src/components/license-activation/LicenseActivationPage.jsx
@@ -4,7 +4,7 @@ import LicenseActivation from './LicenseActivation';
 import AuthenticatedPage from '../app/AuthenticatedPage';
 
 const LicenseActivationPage = () => (
-  <AuthenticatedPage useCache={false}>
+  <AuthenticatedPage useEnterpriseConfigCache={false}>
     <LicenseActivation />
   </AuthenticatedPage>
 

--- a/src/components/license-activation/LicenseActivationPage.jsx
+++ b/src/components/license-activation/LicenseActivationPage.jsx
@@ -4,7 +4,7 @@ import LicenseActivation from './LicenseActivation';
 import AuthenticatedPage from '../app/AuthenticatedPage';
 
 const LicenseActivationPage = () => (
-  <AuthenticatedPage>
+  <AuthenticatedPage useCache={false}>
     <LicenseActivation />
   </AuthenticatedPage>
 


### PR DESCRIPTION
### Description
* adds useCache prop to AuthenticatedPage, removes the use of cache on LicenseActivationPage

### Ticket
[ENT-4089](https://openedx.atlassian.net/browse/ENT-4089)

### Testing instructions
* Checkout branch and log the value of `useCache` to the console from `fetchEnterpriseCustomerConfigForSlug`. 
* Visit different pages within the learner portal. Observe in the console that `useCache` is true on all pages but the license activation page. 
