### PR TITLE
bug: fix race condition in hasValidStartExpirationDates

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "build": "fedx-scripts webpack",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
+    "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx .",
     "is-es5": "es-check es5 ./dist/*.js",
     "precommit": "npm run lint",
     "snapshot": "fedx-scripts jest --updateSnapshot",

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -38,7 +38,9 @@ export const hasTruthyValue = (value) => {
   return values.every(item => !!item);
 };
 
-export const hasValidStartExpirationDates = ({ startDate, expirationDate }) => {
+export const hasValidStartExpirationDates = ({ startDate, expirationDate, endDate }) => {
   const now = moment();
-  return now.isBetween(startDate, expirationDate);
+  // Subscriptions use "expirationDate" while Codes use "endDate"
+  const realEndDate = expirationDate || endDate;
+  return now.isBetween(startDate, realEndDate);
 };

--- a/src/utils/tests/common.test.js
+++ b/src/utils/tests/common.test.js
@@ -1,8 +1,10 @@
+import moment from 'moment';
 import {
   isDefinedAndNotNull,
   createArrayFromValue,
   isDefinedAndNull,
   hasTruthyValue,
+  hasValidStartExpirationDates,
 } from '../common';
 
 function assertTestCaseEquals(testCase, expectedValue) {
@@ -93,6 +95,61 @@ describe('hasTruthyValue', () => {
 
   it('returns false when passed an array with 1 empty string', () => {
     const result = hasTruthyValue(['']);
+    expect(result).toBeFalsy();
+  });
+});
+
+const now = moment();
+const validStartDate = moment(now).subtract(5, 'days');
+const validEndDate = moment(now).add(5, 'days');
+const validExpirationDate = moment(now).add(6, 'days');
+const invalidStartDate = moment(now).add(1, 'days');
+const invalidEndDate = moment(now).subtract(1, 'days');
+const invalidExpirationDate = moment(now).subtract(2, 'days');
+
+describe('hasValidStartExpirationDates', () => {
+  it('returns true when now is between startDate and endDate', () => {
+    const validStartEnd = {
+      startDate: validStartDate,
+      endDate: validEndDate,
+    };
+    const result = hasValidStartExpirationDates(validStartEnd);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns true when now is between startDate and expirationDate', () => {
+    const validStartExp = {
+      startDate: validStartDate,
+      expirationDate: validExpirationDate,
+    };
+    const result = hasValidStartExpirationDates(validStartExp);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns false when startDate is invalid', () => {
+    const invalidStart = {
+      startDate: invalidStartDate,
+      endDate: validEndDate,
+    };
+    const result = hasValidStartExpirationDates(invalidStart);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false when endDate is invalid', () => {
+    const invalidEnd = {
+      startDate: validStartDate,
+      endDate: invalidEndDate,
+    };
+    const result = hasValidStartExpirationDates(invalidEnd);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false when expirationDate is invalid', () => {
+    const invalidExp = {
+      startDate: validStartDate,
+      expirationDate: invalidExpirationDate,
+    };
+    const result = hasValidStartExpirationDates(invalidExp);
     expect(result).toBeFalsy();
   });
 });


### PR DESCRIPTION
### Background
While doing manual end to end testing for Learner Portal with Codes, we found the prices were not showing correctly, particularly in the case of enterprises that had both offers and subscriptions.

The expected behaviour: A user in an enterprise - that has a subscription - with a coupon/code/offer for a non-subscription catalog should see the original price crossed out (or not present in the case of the hide original price flag) and see "Sponsored by <Enterprise Name>".

The actual behaviour: They saw the original price as though they had no offer.

Through a lot of debugging, it was realized this behaviour was inconsistent and we figured out there was a race condition somewhere, ultimately leading us back to this `hasValidStartExpirationDates` function. In trying to debug this, we also noticed that licenses and offers use different variable names for expiration dates that was not reflected in this function. By picking up the `endDate` we no longer pass in an `undefined` which seems to fix whatever bug is happening in Moment (It _should_ handle undefined as an end date and seems to...._sometimes_)

### Changes/Fixes
- Added handling of `endDate` to `hasValidStartExpirationDates`
- Added tests for this function (there were previously none)
- (unrelated) Added `--fix` to commands/scripts because I like the linter fixing things for me.

### Screenshots:

#### Before:
![Screen Shot 2021-03-03 at 12 48 13 PM](https://user-images.githubusercontent.com/66267747/109849067-f10dab00-7c1e-11eb-8891-91c8c8a23532.png)

#### After:
![Screen Shot 2021-03-03 at 12 49 12 PM](https://user-images.githubusercontent.com/66267747/109849078-f4089b80-7c1e-11eb-8147-ed141542a03c.png)
