### PR TITLE
Remove unnecessary banner from dashboard.

### DIFF
--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import Course from './Course';
 import AuthenticatedUserSubsidyPage from '../app/AuthenticatedUserSubsidyPage';
+import OffersAlert from '../enterprise-user-subsidy/OffersAlert';
 
 export default function CoursePage() {
   return (
     <AuthenticatedUserSubsidyPage>
+      <OffersAlert />
       <Course />
     </AuthenticatedUserSubsidyPage>
   );

--- a/src/components/enterprise-user-subsidy/OffersAlert.jsx
+++ b/src/components/enterprise-user-subsidy/OffersAlert.jsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useContext } from 'react';
 
 import { Alert, Container } from '@edx/paragon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { UserSubsidyContext } from '.';
 
-export const getOffersText = (number) => `You have ${number} course redemption voucher${number > 1 ? 's' : ''} left to use.`;
+export const getOffersText = (number) => `You have ${number} enrollment codes${number > 1 ? 's' : ''} left to use.`;
 
-const OffersAlert = ({ offers }) => {
-  if (!offers.offersCount) {
+const OffersAlert = () => {
+  const { offers } = useContext(UserSubsidyContext);
+  if (!offers?.offersCount) {
     return null;
   }
   return (
@@ -19,12 +20,6 @@ const OffersAlert = ({ offers }) => {
       </Container>
     </Alert>
   );
-};
-
-OffersAlert.propTypes = {
-  offers: PropTypes.shape({
-    offersCount: PropTypes.number.isRequired,
-  }).isRequired,
 };
 
 export default OffersAlert;

--- a/src/components/enterprise-user-subsidy/UserSubsidyAlerts.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidyAlerts.jsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { UserSubsidyContext } from '.';
-import OffersAlert from './OffersAlert';
 import SubscriptionSubsidy from './SubscriptionSubsidy';
 
 const UserSubsidyAlerts = () => {
@@ -10,7 +9,6 @@ const UserSubsidyAlerts = () => {
 
   return (
     <>
-      {offers && <OffersAlert offers={offers} />}
       {/**
        * SubscriptionSubsidy takes care of redirecting the user to `/${enterpriseConfig.slug}`
        * if their organization has a subscription plan but they don't have appropriate access

--- a/src/components/enterprise-user-subsidy/tests/OffersAlert.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/OffersAlert.test.jsx
@@ -3,20 +3,39 @@ import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import OffersAlert, { getOffersText } from '../OffersAlert';
+import { UserSubsidyContext } from '..';
+
+/* eslint-disable react/prop-types */
+const OffersAlertWithContext = ({
+  subsidyContext = {},
+}) => (
+  <UserSubsidyContext.Provider value={subsidyContext}>
+    <OffersAlert />
+  </UserSubsidyContext.Provider>
+);
+/* eslint-enable react/prop-types */
 
 describe('<OffersAlert />', () => {
-  const offers = {
-    loading: false,
-    offers: [],
-    offersCount: 3,
-  };
-
   it('renders an alert when loading is complete and there are offers', () => {
-    render(<OffersAlert offers={offers} />);
-    expect(screen.queryByText(getOffersText(offers.offersCount))).toBeInTheDocument();
+    const subsidyContext = {
+      offers: {
+        loading: false,
+        offers: [],
+        offersCount: 3,
+      },
+    };
+    render(<OffersAlertWithContext subsidyContext={subsidyContext} />);
+    expect(screen.queryByText(getOffersText(subsidyContext.offers.offersCount))).toBeInTheDocument();
   });
   it('does not render an alert if there are no offers', () => {
-    render(<OffersAlert offers={{ ...offers, offersCount: 0 }} />);
-    expect(screen.queryByText(getOffersText(offers.offersCount))).not.toBeInTheDocument();
+    const subsidyContext = {
+      offers: {
+        loading: false,
+        offers: [],
+        offersCount: 0,
+      },
+    };
+    render(<OffersAlertWithContext subsidyContext={subsidyContext} />);
+    expect(screen.queryByText(getOffersText(subsidyContext.offers.offersCount))).not.toBeInTheDocument();
   });
 });

--- a/src/components/search/SearchPage.jsx
+++ b/src/components/search/SearchPage.jsx
@@ -3,9 +3,11 @@ import React from 'react';
 import { SearchData } from '@edx/frontend-enterprise';
 import Search from './Search';
 import AuthenticatedUserSubsidyPage from '../app/AuthenticatedUserSubsidyPage';
+import OffersAlert from '../enterprise-user-subsidy/OffersAlert';
 
 const SearchPage = () => (
   <AuthenticatedUserSubsidyPage>
+    <OffersAlert />
     <SearchData>
       <Search />
     </SearchData>


### PR DESCRIPTION
### Background:
While testing Learner Portal with Codes, we noticed the Learner Dashboard showed the voucher banner. This is redundant since we already have the cards on the right that show your subscription and codes.

### Implementation:
- OffersAlert component moved out from under UserSubsidyAlerts.
- Offer context called directly from OffersAlert.
- Updated the language from `course redemption vouchers` to `enrollment codes`

### Screenshots:
The banner correctly missing from the dashboard:
![Screen Shot 2021-03-05 at 1 35 31 PM](https://user-images.githubusercontent.com/66267747/110159221-6b256780-7db8-11eb-8f4e-28c2dc9ee752.png)

The updated language:
![Screen Shot 2021-03-05 at 1 42 07 PM](https://user-images.githubusercontent.com/66267747/110159372-9e67f680-7db8-11eb-92d8-d6da997906f6.png)
