### PR TITLE
ENT-4276 lp codes bugfixes

### DIFF
--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -280,7 +280,7 @@ const useCourseEnrollmentUrl = ({
           license_uuid: subscriptionLicense.uuid,
           course_id: key,
           enterprise_customer_uuid: enterpriseConfig.uuid,
-          // We don't want any sidebar text we show the data consent page from this workflow since 
+          // We don't want any sidebar text we show the data consent page from this workflow since
           // the text on the sidebar is used when a learner is coming from their employer's system.
           left_sidebar_text_override: '',
         };
@@ -291,7 +291,7 @@ const useCourseEnrollmentUrl = ({
         const enrollOptions = {
           ...baseEnrollmentOptions,
           sku,
-          consent_url_param_string: encodeURI('left_sidebar_text_override='), // Deliberately doubly encoded since it will get parsed on the redirect. 
+          consent_url_param_string: encodeURI('left_sidebar_text_override='), // Deliberately doubly encoded since it will get parsed on the redirect.
         };
         // get the index of the first offer that applies to a catalog that the course is in
         const offerForCourse = findOfferForCourse(offers, catalogList);

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -280,6 +280,9 @@ const useCourseEnrollmentUrl = ({
           license_uuid: subscriptionLicense.uuid,
           course_id: key,
           enterprise_customer_uuid: enterpriseConfig.uuid,
+          // We don't want any sidebar text we show the data consent page from this workflow since 
+          // the text on the sidebar is used when a learner is coming from their employer's system.
+          left_sidebar_text_override: '',
         };
         return `${config.LMS_BASE_URL}/enterprise/grant_data_sharing_permissions/?${qs.stringify(enrollOptions)}`;
       }
@@ -288,9 +291,7 @@ const useCourseEnrollmentUrl = ({
         const enrollOptions = {
           ...baseEnrollmentOptions,
           sku,
-          // We don't want any sidebar text we show the data consent page from this workflow:
-          left_sidebar_text_override: '',
-
+          consent_url_param_string: encodeURI('left_sidebar_text_override='), // Deliberately doubly encoded since it will get parsed on the redirect. 
         };
         // get the index of the first offer that applies to a catalog that the course is in
         const offerForCourse = findOfferForCourse(offers, catalogList);

--- a/src/components/course/enrollment/common.jsx
+++ b/src/components/course/enrollment/common.jsx
@@ -33,6 +33,6 @@ const EnrollButtonCta = ({ enrollLabel: EnrollLabel, ...props }) => (
   </EnrollButtonWrapper>
 );
 
-EnrollButtonCta.propTypes = { enrollLabel: PropTypes.shape.isRequired };
+EnrollButtonCta.propTypes = { enrollLabel: PropTypes.node.isRequired };
 
 export { EnrollButtonCta };

--- a/src/components/course/enrollment/components/DisabledEnroll.jsx
+++ b/src/components/course/enrollment/components/DisabledEnroll.jsx
@@ -12,7 +12,7 @@ const EnrollBtnDisabled = ({ enrollLabel }) => (
 );
 
 EnrollBtnDisabled.propTypes = {
-  enrollLabel: PropTypes.shape.isRequired,
+  enrollLabel: PropTypes.node.isRequired,
 };
 
 export default EnrollBtnDisabled;

--- a/src/components/course/enrollment/components/ToCoursewarePage.jsx
+++ b/src/components/course/enrollment/components/ToCoursewarePage.jsx
@@ -36,7 +36,7 @@ const ToCoursewarePage = ({
 };
 
 ToCoursewarePage.propTypes = {
-  enrollLabel: PropTypes.shape.isRequired,
+  enrollLabel: PropTypes.node.isRequired,
   enrollmentUrl: PropTypes.string.isRequired,
   userEnrollment: PropTypes.shape.isRequired,
   subscriptionLicense: PropTypes.shape.isRequired,

--- a/src/components/course/enrollment/components/ToDataSharingConsent.jsx
+++ b/src/components/course/enrollment/components/ToDataSharingConsent.jsx
@@ -16,7 +16,7 @@ const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => (
 );
 
 ToDataSharingConsentPage.propTypes = {
-  enrollLabel: PropTypes.shape.isRequired,
+  enrollLabel: PropTypes.node.isRequired,
   enrollmentUrl: PropTypes.string.isRequired,
 };
 

--- a/src/components/course/enrollment/components/ToVoucherRedeemPage.jsx
+++ b/src/components/course/enrollment/components/ToVoucherRedeemPage.jsx
@@ -29,7 +29,7 @@ const ToVoucherRedeemPage = ({ enrollLabel, enrollmentUrl }) => {
   );
 };
 ToVoucherRedeemPage.propTypes = {
-  enrollLabel: PropTypes.shape.isRequired,
+  enrollLabel: PropTypes.node.isRequired,
   enrollmentUrl: PropTypes.string.isRequired,
 };
 

--- a/src/components/course/enrollment/components/ViewOnDashboard.jsx
+++ b/src/components/course/enrollment/components/ViewOnDashboard.jsx
@@ -22,7 +22,7 @@ const ViewOnDashboard = ({ enrollLabel }) => {
 };
 
 ViewOnDashboard.propTypes = {
-  enrollLabel: PropTypes.shape.isRequired,
+  enrollLabel: PropTypes.node.isRequired,
 };
 
 export default ViewOnDashboard;

--- a/src/components/enterprise-user-subsidy/OffersAlert.jsx
+++ b/src/components/enterprise-user-subsidy/OffersAlert.jsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { UserSubsidyContext } from '.';
 
-export const getOffersText = (number) => `You have ${number} enrollment codes${number > 1 ? 's' : ''} left to use.`;
+export const getOffersText = (number) => `You have ${number} enrollment code${number > 1 ? 's' : ''} left to use.`;
 
 const OffersAlert = () => {
   const { offers } = useContext(UserSubsidyContext);


### PR DESCRIPTION
- Fix for ENT-4276 (Note: requires sister ecommerce PR as well to redirect data sharing parameters)
  - Desire to modify feature to apply to subscription redemptions when called from within learner portal as well as when codes are redeemed.
  - Fixed bug where left sidebar override parameter got lost when ecommerce reconstructed the Data Sharing Consent url and performed a redirect.
- Small other nits: a typo in the 'you have x codes' banner
- Fixed PropTypes warning (after doing investigation into correct PropType)
- 
<img width="787" alt="Screen Shot 2021-03-11 at 3 05 39 PM" src="https://user-images.githubusercontent.com/74684094/110847905-7a565a80-827b-11eb-8948-8954f876b5b4.png">
<img width="1234" alt="Screen Shot 2021-03-11 at 3 04 25 PM" src="https://user-images.githubusercontent.com/74684094/110847907-7a565a80-827b-11eb-8229-441332011f66.png">


