### PR TITLE
ENT-4105: small UX improvements

### DIFF
--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -89,7 +89,7 @@ export default function CourseHeader() {
                     <img
                       src={partner.logoImageUrl}
                       alt={`${partner.name} logo`}
-                      style={{ maxWidth: 160, maxHeight: 44 }}
+                      style={{ maxWidth: 160, maxHeight: 144 }}
                     />
                   </a>
                 ))}

--- a/src/components/course/CourseSkills.jsx
+++ b/src/components/course/CourseSkills.jsx
@@ -13,8 +13,8 @@ export default function CourseSkills() {
   const skillsButtonLabel = showMore ? SKILLS_BUTTON_LABEL.SHOW_LESS : SKILLS_BUTTON_LABEL.SHOW_MORE;
 
   return (
-    <div className="mb-4">
-      <h6> Skills you&apos;ll gain</h6>
+    <div className="mb-5">
+      <h5> Skills you&apos;ll gain</h5>
       <div>
         {skillNames.map((skill, index) => (
           <Badge


### PR DESCRIPTION
Before: 
<img width="1246" alt="Screenshot 2021-03-24 at 10 26 01 PM" src="https://user-images.githubusercontent.com/55431213/112355903-ef03ad00-8cef-11eb-962c-3507a06e8d99.png">


After:
<img width="1220" alt="Screenshot 2021-03-24 at 10 23 15 PM" src="https://user-images.githubusercontent.com/55431213/112355952-f5922480-8cef-11eb-8b6c-7b6019947265.png">
