### PR TITLE
fix: upgrade frontend-enterprise to fix search clear button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1432,9 +1432,9 @@
       }
     },
     "@edx/frontend-enterprise": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise/-/frontend-enterprise-5.4.0.tgz",
-      "integrity": "sha512-6dyewIR1Wjt8ptm8rSLz562Ywa2oyRAjLaI0hyekSEJpYrlowIwqLsmAgTCN8VIZN+2plDexGOH1le7cnZ9i9Q=="
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise/-/frontend-enterprise-5.4.2.tgz",
+      "integrity": "sha512-ff5GSJafxGcKFYDmf3IBQtrk0qDYgB3Xi/xN3s+WOrvzQC+43x+G1VXQ+zXKc1AQUzQCJEz8+pQRhsNPn3j7PA=="
     },
     "@edx/frontend-platform": {
       "version": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.0",
-    "@edx/frontend-enterprise": "5.4.0",
+    "@edx/frontend-enterprise": "5.4.2",
     "@edx/frontend-platform": "1.8.2",
     "@edx/paragon": "13.17.0",
     "@fortawesome/fontawesome-svg-core": "1.2.32",

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -43,7 +43,7 @@ const Search = () => {
       >
         <Configure hitsPerPage={NUM_RESULTS_PER_PAGE} filters={filters} />
         <div className="search-header-wrapper">
-          <SearchHeader />
+          <SearchHeader containerSize="lg" />
         </div>
         <SearchResults />
       </InstantSearch>


### PR DESCRIPTION
## Description

- upgrades frontend-enterprise to 5.4.2
- adds `containerSize` prop to `SearchHeader`

This PR is basically just a version bump for frontend-enterprise:
- 5.4.1 adds a `containerSize` prop to `SearchHeader` with default value of `null`
- 5.4.2 fixes an issue with the functionality of the `SearchHeader` submit and clear actions

## Ticket link

[ENT-4382](https://openedx.atlassian.net/browse/ENT-4382)