### PR TITLE
fix: remove subscription plan API call; use new license subscriptionPlan attribute

### DIFF
--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -9,38 +9,9 @@ import offersReducer, { initialOfferState } from '../offers/data/reducer';
 
 import { LICENSE_STATUS } from './constants';
 import {
-  fetchEnterpriseCustomerSubscriptionPlan,
   fetchSubscriptionLicensesForUser,
 } from './service';
 import { features } from '../../../config';
-
-export function useEnterpriseCustomerSubscriptionPlan(enterpriseUUID) {
-  const [subscriptionPlan, setSubscriptionPlan] = useState();
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    if (!enterpriseUUID) {
-      setSubscriptionPlan(null);
-      return;
-    }
-    fetchEnterpriseCustomerSubscriptionPlan(enterpriseUUID)
-      .then((response) => {
-        const { results } = camelCaseObject(response.data);
-        const activePlans = results.filter(plan => plan.isActive);
-        const activeSubscriptionPlan = activePlans.pop() || null;
-        setSubscriptionPlan(activeSubscriptionPlan);
-      })
-      .catch((error) => {
-        logError(new Error(error));
-        setSubscriptionPlan(null);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [enterpriseUUID]);
-
-  return [subscriptionPlan, isLoading];
-}
 
 export function useSubscriptionLicenseForUser(enterpriseId) {
   const [license, setLicense] = useState();

--- a/src/components/enterprise-user-subsidy/data/service.js
+++ b/src/components/enterprise-user-subsidy/data/service.js
@@ -2,18 +2,6 @@ import qs from 'query-string';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
-export function fetchEnterpriseCustomerSubscriptionPlan(enterpriseUUID) {
-  const queryParams = {
-    enterprise_customer_uuid: enterpriseUUID,
-  };
-  const config = getConfig();
-  const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-subscriptions/?${qs.stringify(queryParams)}`;
-  const httpClient = getAuthenticatedHttpClient({
-    useCache: config.USE_API_CACHE,
-  });
-  return httpClient.get(url);
-}
-
 export function fetchSubscriptionLicensesForUser(enterpriseUUID) {
   const queryParams = {
     enterprise_customer_uuid: enterpriseUUID,

--- a/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
@@ -10,7 +10,6 @@ import { renderWithRouter } from '../../../utils/tests';
 import { LICENSE_STATUS, LOADING_SCREEN_READER_TEXT } from '../data/constants';
 import {
   fetchSubscriptionLicensesForUser,
-  fetchEnterpriseCustomerSubscriptionPlan,
 } from '../data/service';
 import { fetchOffers } from '../offers/data/service';
 
@@ -75,7 +74,6 @@ describe('UserSubsidy', () => {
       };
       fetchOffers.mockResolvedValueOnce(response);
       fetchSubscriptionLicensesForUser.mockResolvedValueOnce(response);
-      fetchEnterpriseCustomerSubscriptionPlan.mockResolvedValueOnce(response);
     });
 
     afterEach(() => {
@@ -124,7 +122,6 @@ describe('UserSubsidy', () => {
           results: [],
         },
       };
-      fetchEnterpriseCustomerSubscriptionPlan.mockResolvedValueOnce(response);
       fetchSubscriptionLicensesForUser.mockResolvedValueOnce(response);
       const Component = (
         <UserSubsidyWithAppContext>
@@ -134,7 +131,6 @@ describe('UserSubsidy', () => {
       renderWithRouter(Component, {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
-      expect(fetchEnterpriseCustomerSubscriptionPlan).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledWith({
         enterprise_uuid: TEST_ENTERPRISE_UUID,
@@ -147,11 +143,6 @@ describe('UserSubsidy', () => {
     });
 
     test('with license, shows correct portal access', async () => {
-      fetchEnterpriseCustomerSubscriptionPlan.mockResolvedValueOnce({
-        data: {
-          results: [mockSubscriptionPlan],
-        },
-      });
       fetchSubscriptionLicensesForUser.mockResolvedValueOnce({
         data: {
           results: [{
@@ -168,7 +159,6 @@ describe('UserSubsidy', () => {
       renderWithRouter(Component, {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
-      expect(fetchEnterpriseCustomerSubscriptionPlan).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledWith({
         enterprise_uuid: TEST_ENTERPRISE_UUID,
@@ -182,16 +172,12 @@ describe('UserSubsidy', () => {
     });
 
     test('provides license data', async () => {
-      fetchEnterpriseCustomerSubscriptionPlan.mockResolvedValueOnce({
-        data: {
-          results: [mockSubscriptionPlan],
-        },
-      });
       fetchSubscriptionLicensesForUser.mockResolvedValueOnce({
         data: {
           results: [{
             uuid: TEST_LICENSE_UUID,
             status: LICENSE_STATUS.ACTIVATED,
+            subscriptionPlan: mockSubscriptionPlan,
           }],
         },
       });
@@ -203,7 +189,6 @@ describe('UserSubsidy', () => {
       renderWithRouter(Component, {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
-      expect(fetchEnterpriseCustomerSubscriptionPlan).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledWith({
         enterprise_uuid: TEST_ENTERPRISE_UUID,
@@ -217,16 +202,12 @@ describe('UserSubsidy', () => {
     });
 
     test('provides offers data', async () => {
-      fetchEnterpriseCustomerSubscriptionPlan.mockResolvedValueOnce({
-        data: {
-          results: [mockSubscriptionPlan],
-        },
-      });
       fetchSubscriptionLicensesForUser.mockResolvedValueOnce({
         data: {
           results: [{
             uuid: TEST_LICENSE_UUID,
             status: LICENSE_STATUS.ACTIVATED,
+            subscriptionPlan: mockSubscriptionPlan,
           }],
         },
       });
@@ -238,7 +219,6 @@ describe('UserSubsidy', () => {
       renderWithRouter(Component, {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
-      expect(fetchEnterpriseCustomerSubscriptionPlan).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledTimes(1);
       expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, full_discount_only: 'True', is_active: 'True' });
@@ -251,9 +231,13 @@ describe('UserSubsidy', () => {
 
   describe('with subscription plan that has started, but not yet ended, no offers', () => {
     beforeEach(() => {
-      fetchEnterpriseCustomerSubscriptionPlan.mockResolvedValueOnce({
+      fetchSubscriptionLicensesForUser.mockResolvedValueOnce({
         data: {
-          results: [mockSubscriptionPlan],
+          results: [{
+            uuid: TEST_LICENSE_UUID,
+            status: LICENSE_STATUS.ACTIVATED,
+            subscriptionPlan: mockSubscriptionPlan,
+          }],
         },
       });
       fetchOffers.mockResolvedValueOnce({
@@ -274,6 +258,7 @@ describe('UserSubsidy', () => {
           results: [{
             uuid: TEST_LICENSE_UUID,
             status: LICENSE_STATUS.ACTIVATED,
+            subscriptionPlan: mockSubscriptionPlan,
           }],
         },
       });
@@ -290,7 +275,6 @@ describe('UserSubsidy', () => {
       // assert component is initially loading
       expect(screen.getByText(LOADING_SCREEN_READER_TEXT)).toBeInTheDocument();
 
-      expect(fetchEnterpriseCustomerSubscriptionPlan).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
 
       await waitFor(() => {


### PR DESCRIPTION
**NOTE**: https://github.com/edx/license-manager/pull/211 has to be merged first.

We previously obtained license and subscriptionPlan information from 2 separate API calls. This meant we weren't ensuring the subscriptionPlan foreign key on the license object actually matched the subscriptionPlan we were returning. To make matters worse, when there are multiple subscription Plans we just returned a random one.

We now associate license to subscription in a one to one relationship by pulling the subscription plan information associated with the license in the backend API call.

Thus, this mostly just removes the subscription plan fetch call and everything upstream(down? idk, everything defined in the `useEnterpriseCustomerSubscriptionPlan` method was only used in that method and thus can also be tossed out).

It also makes sure subscriptionPlan is now assigned via the subscriptionLicense object.