### PR TITLE
fix: page does not fail if course has no skills

### DIFF
--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -106,7 +106,7 @@ export default function CourseHeader() {
                 dangerouslySetInnerHTML={{ __html: course.shortDescription }}
               />
             )}
-            {course.skillNames.length > 0 && <CourseSkills />}
+            {course.skillNames?.length > 0 && <CourseSkills />}
             {catalog.containsContentItems ? (
               <>
                 <CourseRunSelector />


### PR DESCRIPTION
Previously, if a course had no listed skills, the page would error. This prevents us from trying to access the length of an array that does not exist.