### PR TITLE
fix: reduce noisy JS errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,9 +1501,9 @@
       }
     },
     "@edx/frontend-platform": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.9.6.tgz",
-      "integrity": "sha512-P5hG3DMoai7ORein2gBurxwG5tFD651/s/NgrdS4NwuLbPcFYMyhSVovPB4oMImQI8nJChf/AmG7m+LA88C4Gg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.11.0.tgz",
+      "integrity": "sha512-XtqKPWUvXzPJLlIEsoLMuac3TvTtAe1GY9MKu1QQsZDget1plDZqaf3ByRbuxOW8b2g2JVPvFx+Jm3FxTcrmIQ==",
       "requires": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "axios": "0.21.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@edx/frontend-enterprise-catalog-search": "0.1.8",
     "@edx/frontend-enterprise-logistration": "0.1.5",
     "@edx/frontend-enterprise-utils": "0.1.5",
-    "@edx/frontend-platform": "1.9.6",
+    "@edx/frontend-platform": "1.11.0",
     "@edx/paragon": "14.6.1",
     "@fortawesome/fontawesome-svg-core": "1.2.32",
     "@fortawesome/free-brands-svg-icons": "5.15.1",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,6 +34,9 @@ initialize({
         ALGOLIA_INDEX_NAME: process.env.ALGOLIA_INDEX_NAME || null,
         INTEGRATION_WARNING_DISMISSED_COOKIE_NAME: process.env.INTEGRATION_WARNING_DISMISSED_COOKIE_NAME || null,
         SHOW_MAINTENANCE_ALERT: process.env.SHOW_MAINTENANCE_ALERT,
+        // Logs JS errors matching the following regex as NewRelic page actions instead of
+        // errors,reducing JS error noise.
+        IGNORED_ERROR_REGEX: '(Axios Error|\'removeChild\'|Script error|getReadModeExtract)',
       });
     },
   },


### PR DESCRIPTION
Treat Axios errors and third-party script errors as NewRelic page actions instead of JS errors, so they don't affect our alerting.

See https://openedx.atlassian.net/wiki/spaces/PT/pages/2796617772/MFE+JS+Error+and+Info+Logging#Summary for more details on this works.