### PR TITLE
fix: add segment and Algolia events for search CTR and conversions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,9 +2011,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "14.16.10",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.16.10.tgz",
-      "integrity": "sha512-pIftyWuZ77FfJpjkTxDPt7e0AGzzwCa+KRH4EiEG+aNCEoUdwBvmfbE3eW0Ijm85WFlr/6Zod3BnWhD2bhj8Hg==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-16.3.1.tgz",
+      "integrity": "sha512-3NXCLXjjkso94EzuLEcd/FbYQDIGZmSK5jncOkL6Nf1Y0+1xDz4Y/0Ai9HY2xmkbmv8vDSmb9lyMDV7jyxV/Pg==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -2024,6 +2024,7 @@
         "classnames": "^2.2.6",
         "email-prop-type": "^3.0.0",
         "font-awesome": "^4.7.0",
+        "lodash.uniqby": "^4.7.0",
         "mailto-link": "^1.0.0",
         "prop-types": "^15.7.2",
         "react-bootstrap": "^1.3.0",
@@ -2033,7 +2034,6 @@
         "react-responsive": "^6.1.1",
         "react-table": "^7.6.1",
         "react-transition-group": "^4.0.0",
-        "sanitize-html": "^2.0.0",
         "tabbable": "^4.0.0",
         "uncontrollable": "7.2.1"
       },
@@ -3375,9 +3375,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
-      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-KibDWL6nshuOJ0fu8ll7QnV/LVTo3PzQ9aCPnRUYPfX7eZohHwLIdNHj7pftanREzHNP4/nJa8oeM73uSiavMQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -5995,7 +5995,8 @@
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
     },
     "colors": {
       "version": "0.6.2",
@@ -6972,7 +6973,8 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -7226,6 +7228,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
       "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
@@ -7236,6 +7239,7 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
           "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "dev": true,
           "requires": {
             "domelementtype": "^2.2.0"
           }
@@ -7251,7 +7255,8 @@
     "domelementtype": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "dev": true
     },
     "domexception": {
       "version": "2.0.1",
@@ -7270,18 +7275,11 @@
         }
       }
     },
-    "domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
-      "requires": {
-        "domelementtype": "^2.2.0"
-      }
-    },
     "domutils": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
       "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -7292,6 +7290,7 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
           "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "dev": true,
           "requires": {
             "domelementtype": "^2.2.0"
           }
@@ -7550,7 +7549,8 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true
     },
     "enzyme": {
       "version": "3.11.0",
@@ -9790,17 +9790,6 @@
             "object.getownpropertydescriptors": "^2.0.3"
           }
         }
-      }
-    },
-    "htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
       }
     },
     "http-cache-semantics": {
@@ -12100,7 +12089,8 @@
     "klona": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
-      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
+      "dev": true
     },
     "lcov-parse": {
       "version": "1.0.0",
@@ -12301,6 +12291,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -13009,11 +13004,6 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
-    },
-    "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13829,11 +13819,6 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
-    },
-    "parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse5": {
       "version": "6.0.1",
@@ -15433,16 +15418,16 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-focus-lock": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.1.tgz",
-      "integrity": "sha512-gOToRZKVEymGEjFaTRUKgJsdYQrNosoiK7yZnXnnd8bYew4vMzk3Rxb0Q4nyrGwsFuUmgQiSAulQirA0J+v4hA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
+      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.9.1",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.2",
-        "use-callback-ref": "^1.2.1",
-        "use-sidecar": "^1.0.1"
+        "react-clientside-effect": "^1.2.5",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
       }
     },
     "react-focus-on": {
@@ -15536,9 +15521,9 @@
       }
     },
     "react-overlays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.1.0.tgz",
-      "integrity": "sha512-Qp8dqDIIYgQoHxOGVKHwvQUkDe70/Ja/6dn8iCQAXyPvvpks3+T8scLTZLK8MPBBu+X8ustas6y4U6M6zdmCjA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.1.1.tgz",
+      "integrity": "sha512-eCN2s2/+GVZzpnId4XVWtvDPYYBD2EtOGP74hE+8yDskPzFy9+pV1H3ZZihxuRdEbQzzacySaaDkR7xE0ydl4Q==",
       "requires": {
         "@babel/runtime": "^7.13.8",
         "@popperjs/core": "^2.8.6",
@@ -15577,9 +15562,9 @@
       }
     },
     "react-remove-scroll": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.2.tgz",
-      "integrity": "sha512-mMSIZYQF3jS2uRJXeFDRaVGA+BGs/hIryV64YUKsHFtpgwZloOUcdu0oW8K6OU8uLHt/kM5d0lUZbdpIVwgXtQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz",
+      "integrity": "sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==",
       "requires": {
         "react-remove-scroll-bar": "^2.1.0",
         "react-style-singleton": "^2.1.0",
@@ -16599,42 +16584,6 @@
         "walker": "~1.0.5"
       }
     },
-    "sanitize-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.4.0.tgz",
-      "integrity": "sha512-Y1OgkUiTPMqwZNRLPERSEi39iOebn2XJLbeiGOBhaJD/yLqtLGu6GE5w7evx177LeGgSE+4p4e107LMiydOf6A==",
-      "requires": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^6.0.0",
-        "is-plain-object": "^5.0.0",
-        "klona": "^2.0.3",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.0.2"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "is-plain-object": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-        },
-        "postcss": {
-          "version": "8.3.5",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-          "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
-          "requires": {
-            "colorette": "^1.2.2",
-            "nanoid": "^3.1.23",
-            "source-map-js": "^0.6.2"
-          }
-        }
-      }
-    },
     "sass": {
       "version": "1.26.11",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.11.tgz",
@@ -17216,11 +17165,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
-    },
-    "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-loader": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@edx/frontend-enterprise-logistration": "0.1.5",
     "@edx/frontend-enterprise-utils": "0.1.5",
     "@edx/frontend-platform": "1.11.0",
-    "@edx/paragon": "^14.16.10",
+    "@edx/paragon": "16.3.1",
     "@fortawesome/fontawesome-svg-core": "1.2.32",
     "@fortawesome/free-brands-svg-icons": "5.15.1",
     "@fortawesome/free-regular-svg-icons": "5.15.1",
@@ -51,7 +51,6 @@
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
-    "sanitize-html": "^2.4.0",
     "universal-cookie": "4.0.4"
   },
   "devDependencies": {

--- a/src/components/course/Course.jsx
+++ b/src/components/course/Course.jsx
@@ -1,8 +1,6 @@
-import React, {
-  useContext, useEffect, useMemo, useState,
-} from 'react';
+import React, { useContext, useMemo } from 'react';
 import qs from 'query-string';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import MediaQuery from 'react-responsive';
 import { breakpoints, Container, Row } from '@edx/paragon';
@@ -16,41 +14,24 @@ import CourseHeader from './CourseHeader';
 import CourseMainContent from './CourseMainContent';
 import CourseSidebar from './CourseSidebar';
 
-import { useAllCourseData } from './data/hooks';
+import { useAllCourseData, useExtractAndRemoveSearchParamsFromURL } from './data/hooks';
 import { getActiveCourseRun, getAvailableCourseRuns } from './data/utils';
 import NotFoundPage from '../NotFoundPage';
 
 export default function Course() {
   const { courseKey } = useParams();
-  const [algoliaSearchParams, setAlgoliaSearchParams] = useState({
-    queryId: undefined,
-    objectId: undefined,
-  });
   const { enterpriseConfig } = useContext(AppContext);
   const { search } = useLocation();
-  const history = useHistory();
 
   const queryParams = useMemo(
     () => camelCaseObject(qs.parse(search)),
     [search],
   );
-  const { courseRunKey, queryId, objectId } = queryParams;
+  const { courseRunKey } = queryParams;
 
   // extract search queryId and objectId that led to this course page view from
   // the URL query parameters and then remove it to keep the URLs clean.
-  useEffect(
-    () => {
-      if (queryId && objectId) {
-        setAlgoliaSearchParams({ queryId, objectId });
-        delete queryParams.queryId;
-        delete queryParams.objectId;
-        history.replace({
-          search: qs.stringify(queryParams),
-        });
-      }
-    },
-    [queryId, objectId],
-  );
+  const algoliaSearchParams = useExtractAndRemoveSearchParamsFromURL();
 
   const [courseData, fetchError] = useAllCourseData({
     courseKey,

--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { useLocation } from 'react-router-dom';
 import qs from 'query-string';
-import { Breadcrumb, Container, StatusAlert } from '@edx/paragon';
+import { Breadcrumb, Container, Alert } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { CourseContext } from './CourseContextProvider';
@@ -41,19 +41,10 @@ export default function CourseHeader() {
   const renderFailedEnrollmentAlert = () => (
     <>
       <Container size="lg" className="pt-3">
-        <StatusAlert
-          alertType="danger"
-          className="mb-0"
-          dialog={(
-            <>
-              You were not enrolled in your selected course.
-              In order to enroll, you must accept the data sharing consent terms.
-              Please {renderContactHelpText()} for further information.
-            </>
-          )}
-          dismissible={false}
-          open
-        />
+        <Alert variant="danger">
+          You were not enrolled in your selected course. In order to enroll, you must accept the data sharing
+          consent terms. Please {renderContactHelpText(Alert.Link)} for further information.
+        </Alert>
       </Container>
     </>
   );

--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -1,8 +1,11 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from '@edx/paragon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+
+import { CourseContext } from './CourseContextProvider';
+import { useTrackSearchConversionClickHandler } from './data/hooks';
 
 export const ENROLL_MODAL_TEXT_NO_OFFERS = 'Your organization has not provided you with access to courses, but you may still enroll in this course after payment.';
 export const createUseVoucherText = offersCount => `Enrolling in this course will use 1 of your ${offersCount} enrollment codes.`;
@@ -27,8 +30,21 @@ const EnrollModal = ({
   offersCount,
   setIsModalOpen,
 }) => {
-  const { fullOffers, noOffers } = modalText;
+  const {
+    state: {
+      activeCourseRun: { key: courseKey },
+      algoliaSearchParams,
+    },
+  } = useContext(CourseContext);
+  const handleTrackingClick = useTrackSearchConversionClickHandler({
+    href: enrollmentUrl,
+    objectId: algoliaSearchParams.objectId,
+    queryId: algoliaSearchParams.queryId,
+    courseKey,
+    eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_ecommerce_basket.clicked',
+  });
   const [submitting, setSubmitting] = useState(false);
+  const { fullOffers, noOffers } = modalText;
   const buttonText = courseHasOffer ? fullOffers.button : noOffers.button;
   const enrollText = courseHasOffer ? fullOffers.body(offersCount) : noOffers.body;
   const titleText = courseHasOffer ? fullOffers.title : noOffers.title;
@@ -40,8 +56,18 @@ const EnrollModal = ({
       title={titleText}
       body={<div><p>{enrollText}</p></div>}
       buttons={[
-        <a className="btn btn-primary" href={enrollmentUrl} role="button" onClick={() => setSubmitting(true)}>
-          <>{submitting && <FontAwesomeIcon icon={faSpinner} alt="loading" className="fa-spin mr-2" />}{buttonText}</>
+        <a
+          className="btn btn-primary btn-brand-primary"
+          href={enrollmentUrl}
+          onClick={(e) => {
+            setSubmitting(true);
+            handleTrackingClick(e);
+          }}
+        >
+          <>
+            {submitting && <FontAwesomeIcon icon={faSpinner} alt="loading" className="fa-spin mr-2" />}
+            {buttonText}
+          </>
         </a>,
       ]}
       onClose={() => setIsModalOpen(false)}

--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -1,10 +1,9 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from '@edx/paragon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
-import { CourseContext } from './CourseContextProvider';
 import { useTrackSearchConversionClickHandler } from './data/hooks';
 
 export const ENROLL_MODAL_TEXT_NO_OFFERS = 'Your organization has not provided you with access to courses, but you may still enroll in this course after payment.';
@@ -30,17 +29,8 @@ const EnrollModal = ({
   offersCount,
   setIsModalOpen,
 }) => {
-  const {
-    state: {
-      activeCourseRun: { key: courseKey },
-      algoliaSearchParams,
-    },
-  } = useContext(CourseContext);
   const handleTrackingClick = useTrackSearchConversionClickHandler({
     href: enrollmentUrl,
-    objectId: algoliaSearchParams.objectId,
-    queryId: algoliaSearchParams.queryId,
-    courseKey,
     eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_ecommerce_basket.clicked',
   });
   const [submitting, setSubmitting] = useState(false);

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -368,9 +368,6 @@ export const useExtractAndRemoveSearchParamsFromURL = () => {
  *
  * @param {object} args
  * @param {string} args.href If click handler is used on a hyperlink, this is the destination url.
- * @param {string} args.objectId Algolia object id
- * @param {string} args.queryId Algolia query id
- * @param {string} args.courseKey Unique course key identifying the course
  * @param {string} args.eventName Name of the event
  *
  * @returns Click handler function for clicks on buttons, external hyperlinks (with a delay), and
@@ -383,7 +380,7 @@ export const useTrackSearchConversionClickHandler = ({ href, eventName }) => {
       algoliaSearchParams,
     },
   } = useContext(CourseContext);
-  const CLICK_DELAY_MS = 300;
+  const CLICK_DELAY_MS = 300; // 300ms replicates Segment's ``trackLink`` function
   const handleClick = useCallback(
     (e) => {
       const { queryId, objectId } = algoliaSearchParams;

--- a/src/components/course/data/hooks.js
+++ b/src/components/course/data/hooks.js
@@ -325,7 +325,7 @@ useCourseEnrollmentUrl.propTypes = {
 };
 
 /**
- * A hook that parses that the URL query parameters to extract an objectId and queryId and then
+ * A hook that parses the URL query parameters to extract an objectId and queryId and then
  * immediately remove them from the URL via a history replace to keep the URLs clean.
  *
  * @returns An object containing the Algolia objectId and queryId that led to a page view of the Course page.

--- a/src/components/course/enrollment/components/ToCoursewarePage.jsx
+++ b/src/components/course/enrollment/components/ToCoursewarePage.jsx
@@ -1,11 +1,13 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { Hyperlink } from '@edx/paragon';
 
 import { AppContext } from '@edx/frontend-platform/react';
 import { CourseContext } from '../../CourseContextProvider';
 import { EnrollButtonCta } from '../common';
 import { shouldUpgradeUserEnrollment, createCourseInfoUrl } from '../../data/utils';
+import { useTrackSearchConversionClickHandler } from '../../data/hooks';
 
 import { enrollLinkClass } from '../constants';
 
@@ -17,7 +19,12 @@ const ToCoursewarePage = ({
   enrollLabel, enrollmentUrl, userEnrollment, subscriptionLicense,
 }) => {
   const { config } = useContext(AppContext);
-  const { state: { activeCourseRun: { key: courseKey } } } = useContext(CourseContext);
+  const {
+    state: {
+      activeCourseRun: { key: courseKey },
+      algoliaSearchParams,
+    },
+  } = useContext(CourseContext);
   const courseInfoUrl = createCourseInfoUrl({ baseUrl: config.LMS_BASE_URL, courseKey });
   const shouldUseEnrollmentUrl = shouldUpgradeUserEnrollment({
     userEnrollment,
@@ -25,12 +32,21 @@ const ToCoursewarePage = ({
     enrollmentUrl,
   });
   const landingUrl = shouldUseEnrollmentUrl ? enrollmentUrl : courseInfoUrl;
+  const handleClick = useTrackSearchConversionClickHandler({
+    href: landingUrl,
+    objectId: algoliaSearchParams.objectId,
+    queryId: algoliaSearchParams.queryId,
+    courseKey,
+    eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_courseware.clicked',
+  });
 
   return (
     <EnrollButtonCta
       enrollLabel={enrollLabel}
-      className={classNames(enrollLinkClass, 'btn-brand-primary')}
-      href={landingUrl}
+      className={classNames('btn btn-primary btn-brand-primary', enrollLinkClass)}
+      destination={landingUrl}
+      as={Hyperlink}
+      onClick={handleClick}
     />
   );
 };
@@ -38,8 +54,12 @@ const ToCoursewarePage = ({
 ToCoursewarePage.propTypes = {
   enrollLabel: PropTypes.node.isRequired,
   enrollmentUrl: PropTypes.string.isRequired,
-  userEnrollment: PropTypes.shape.isRequired,
-  subscriptionLicense: PropTypes.shape.isRequired,
+  userEnrollment: PropTypes.shape().isRequired,
+  subscriptionLicense: PropTypes.shape(),
+};
+
+ToCoursewarePage.defaultProps = {
+  subscriptionLicense: undefined,
 };
 
 export default ToCoursewarePage;

--- a/src/components/course/enrollment/components/ToCoursewarePage.jsx
+++ b/src/components/course/enrollment/components/ToCoursewarePage.jsx
@@ -22,7 +22,6 @@ const ToCoursewarePage = ({
   const {
     state: {
       activeCourseRun: { key: courseKey },
-      algoliaSearchParams,
     },
   } = useContext(CourseContext);
   const courseInfoUrl = createCourseInfoUrl({ baseUrl: config.LMS_BASE_URL, courseKey });
@@ -34,9 +33,6 @@ const ToCoursewarePage = ({
   const landingUrl = shouldUseEnrollmentUrl ? enrollmentUrl : courseInfoUrl;
   const handleClick = useTrackSearchConversionClickHandler({
     href: landingUrl,
-    objectId: algoliaSearchParams.objectId,
-    queryId: algoliaSearchParams.queryId,
-    courseKey,
     eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_courseware.clicked',
   });
 

--- a/src/components/course/enrollment/components/ToDataSharingConsent.jsx
+++ b/src/components/course/enrollment/components/ToDataSharingConsent.jsx
@@ -19,7 +19,7 @@ const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => {
       enrollLabel={enrollLabel}
       as={Hyperlink}
       className={classNames('btn btn-primary btn-brand-primary', enrollLinkClass)}
-      href={enrollmentUrl}
+      destination={enrollmentUrl}
       onClick={handleClick}
     />
   );

--- a/src/components/course/enrollment/components/ToDataSharingConsent.jsx
+++ b/src/components/course/enrollment/components/ToDataSharingConsent.jsx
@@ -1,26 +1,16 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Hyperlink } from '@edx/paragon';
 
-import { CourseContext } from '../../CourseContextProvider';
 import { useTrackSearchConversionClickHandler } from '../../data/hooks';
 import { enrollLinkClass } from '../constants';
 import { EnrollButtonCta } from '../common';
 
 // Data sharing consent
 const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => {
-  const {
-    state: {
-      activeCourseRun: { key: courseKey },
-      algoliaSearchParams,
-    },
-  } = useContext(CourseContext);
   const handleClick = useTrackSearchConversionClickHandler({
     href: enrollmentUrl,
-    objectId: algoliaSearchParams.objectId,
-    queryId: algoliaSearchParams.queryId,
-    courseKey,
     eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_dsc.clicked',
   });
 

--- a/src/components/course/enrollment/components/ToDataSharingConsent.jsx
+++ b/src/components/course/enrollment/components/ToDataSharingConsent.jsx
@@ -1,19 +1,39 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { Hyperlink } from '@edx/paragon';
 
+import { CourseContext } from '../../CourseContextProvider';
+import { useTrackSearchConversionClickHandler } from '../../data/hooks';
 import { enrollLinkClass } from '../constants';
 import { EnrollButtonCta } from '../common';
 
 // Data sharing consent
-const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => (
-  <EnrollButtonCta
-    enrollLabel={enrollLabel}
-    as="a"
-    className={classNames('btn btn-primary btn-brand-primary', enrollLinkClass)}
-    href={enrollmentUrl}
-  />
-);
+const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => {
+  const {
+    state: {
+      activeCourseRun: { key: courseKey },
+      algoliaSearchParams,
+    },
+  } = useContext(CourseContext);
+  const handleClick = useTrackSearchConversionClickHandler({
+    href: enrollmentUrl,
+    objectId: algoliaSearchParams.objectId,
+    queryId: algoliaSearchParams.queryId,
+    courseKey,
+    eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_dsc.clicked',
+  });
+
+  return (
+    <EnrollButtonCta
+      enrollLabel={enrollLabel}
+      as={Hyperlink}
+      className={classNames('btn btn-primary btn-brand-primary', enrollLinkClass)}
+      href={enrollmentUrl}
+      onClick={handleClick}
+    />
+  );
+};
 
 ToDataSharingConsentPage.propTypes = {
   enrollLabel: PropTypes.node.isRequired,

--- a/src/components/course/enrollment/components/ViewOnDashboard.jsx
+++ b/src/components/course/enrollment/components/ViewOnDashboard.jsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 
-import { CourseContext } from '../../CourseContextProvider';
 import { useTrackSearchConversionClickHandler } from '../../data/hooks';
 import { EnrollButtonCta } from '../common';
 
@@ -12,16 +11,7 @@ import { enrollLinkClass } from '../constants';
 
 const ViewOnDashboard = ({ enrollLabel }) => {
   const { enterpriseConfig } = useContext(AppContext);
-  const {
-    state: {
-      activeCourseRun: { key: courseKey },
-      algoliaSearchParams,
-    },
-  } = useContext(CourseContext);
   const handleClick = useTrackSearchConversionClickHandler({
-    objectId: algoliaSearchParams.objectId,
-    queryId: algoliaSearchParams.queryId,
-    courseKey,
     eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_dashboard.clicked',
   });
 

--- a/src/components/course/enrollment/components/ViewOnDashboard.jsx
+++ b/src/components/course/enrollment/components/ViewOnDashboard.jsx
@@ -2,21 +2,36 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
-
 import { AppContext } from '@edx/frontend-platform/react';
+
+import { CourseContext } from '../../CourseContextProvider';
+import { useTrackSearchConversionClickHandler } from '../../data/hooks';
 import { EnrollButtonCta } from '../common';
 
 import { enrollLinkClass } from '../constants';
 
-// view on dashboard
 const ViewOnDashboard = ({ enrollLabel }) => {
   const { enterpriseConfig } = useContext(AppContext);
+  const {
+    state: {
+      activeCourseRun: { key: courseKey },
+      algoliaSearchParams,
+    },
+  } = useContext(CourseContext);
+  const handleClick = useTrackSearchConversionClickHandler({
+    objectId: algoliaSearchParams.objectId,
+    queryId: algoliaSearchParams.queryId,
+    courseKey,
+    eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_dashboard.clicked',
+  });
+
   return (
     <EnrollButtonCta
       enrollLabel={enrollLabel}
       as={Link}
       className={classNames('btn btn-primary btn-brand-primary', enrollLinkClass)}
       to={`/${enterpriseConfig.slug}`}
+      onClick={handleClick}
     />
   );
 };

--- a/src/components/course/tests/EnrollModal.test.jsx
+++ b/src/components/course/tests/EnrollModal.test.jsx
@@ -1,7 +1,26 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';
+
+import { CourseContextProvider } from '../CourseContextProvider';
 import EnrollModal, { modalText } from '../EnrollModal';
+
+const baseCourseInitialState = {
+  activeCourseRun: {
+    key: 'test-course-run-key',
+  },
+  algoliaSearchParams: {
+    queryId: undefined,
+    objectId: undefined,
+  },
+};
+
+// eslint-disable-next-line react/prop-types
+const EnrollModalWrapper = ({ courseState = baseCourseInitialState, modalProps }) => (
+  <CourseContextProvider initialState={courseState}>
+    <EnrollModal {...modalProps} />
+  </CourseContextProvider>
+);
 
 describe('<EnrollModal />', () => {
   const defaultProps = {
@@ -12,19 +31,28 @@ describe('<EnrollModal />', () => {
     courseHasOffer: true,
   };
   it('displays the correct text when user has valid offers', () => {
-    render(<EnrollModal {...defaultProps} />);
+    render(<EnrollModalWrapper modalProps={defaultProps} />);
     expect(screen.getByText(modalText.fullOffers.title)).toBeInTheDocument();
     expect(screen.getByText(modalText.fullOffers.body(defaultProps.offersCount))).toBeInTheDocument();
     expect(screen.getByText(modalText.fullOffers.button)).toBeInTheDocument();
   });
   it('displays the correct text when user has no offers', () => {
-    render(<EnrollModal {...defaultProps} offersCount={0} courseHasOffer={false} />);
+    const modalProps = {
+      ...defaultProps,
+      offersCount: 0,
+      courseHasOffer: false,
+    };
+    render(<EnrollModalWrapper modalProps={modalProps} />);
     expect(screen.getByText(modalText.noOffers.title)).toBeInTheDocument();
     expect(screen.getByText(modalText.noOffers.body)).toBeInTheDocument();
     expect(screen.getByText(modalText.noOffers.button)).toBeInTheDocument();
   });
   it('displays the correct text when user does not have a valid offer', () => {
-    render(<EnrollModal {...defaultProps} courseHasOffer={false} />);
+    const modalProps = {
+      ...defaultProps,
+      courseHasOffer: false,
+    };
+    render(<EnrollModalWrapper modalProps={modalProps} />);
     expect(screen.getByText(modalText.noOffers.title)).toBeInTheDocument();
     expect(screen.getByText(modalText.noOffers.body)).toBeInTheDocument();
     expect(screen.getByText(modalText.noOffers.button)).toBeInTheDocument();

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
 import MediaQuery from 'react-responsive';
 import {
-  Container, StatusAlert, Row, breakpoints,
+  Container, Alert, Row, breakpoints, useToggle,
 } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -19,24 +19,13 @@ export const LICENCE_ACTIVATION_MESSAGE = 'Your license has been successfully ac
 export default function Dashboard() {
   const { enterpriseConfig } = useContext(AppContext);
   const { subscriptionPlan } = useContext(UserSubsidyContext);
-
   const { state } = useLocation();
+  const [isActivationAlertOpen, , closeActivationAlert] = useToggle(!!state?.activationSuccess);
 
   const renderLicenseActivationSuccess = () => (
-    <>
-      <div>
-        <StatusAlert
-          alertType="success"
-          dialog={(
-            <>
-              {LICENCE_ACTIVATION_MESSAGE}
-            </>
-          )}
-          onClose={() => {}}
-          open
-        />
-      </div>
-    </>
+    <Alert variant="success" show={isActivationAlertOpen} onClose={closeActivationAlert} dismissible>
+      {LICENCE_ACTIVATION_MESSAGE}
+    </Alert>
   );
 
   const PAGE_TITLE = `Dashboard - ${enterpriseConfig.name}`;
@@ -45,7 +34,7 @@ export default function Dashboard() {
     <>
       <Helmet title={PAGE_TITLE} />
       <Container size="lg" className="py-5">
-        {state?.activationSuccess && renderLicenseActivationSuccess()}
+        {renderLicenseActivationSuccess()}
         <Row>
           <MainContent>
             <DashboardMainContent />

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx
@@ -2,13 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
-  Input,
-  Modal,
-  StatusAlert,
-  StatefulButton,
+  Input, Modal, Alert, StatefulButton,
 } from '@edx/paragon';
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Error } from '@edx/paragon/icons';
 
 import { updateEmailSettings } from './data';
 
@@ -121,21 +117,9 @@ class EmailSettingsModal extends Component {
         body={(
           <>
             {error && (
-              <StatusAlert
-                alertType="danger"
-                dialog={(
-                  <div className="d-flex">
-                    <div>
-                      <FontAwesomeIcon className="mr-3" icon={faExclamationTriangle} />
-                    </div>
-                    <div>
-                      An error occurred while saving your email settings. Please try again.
-                    </div>
-                  </div>
-                )}
-                dismissible={false}
-                open
-              />
+              <Alert variant="danger" icon={Error}>
+                An error occurred while saving your email settings. Please try again.
+              </Alert>
             )}
             <div className="form-check">
               <Input

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/ModalError.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/ModalError.jsx
@@ -1,32 +1,15 @@
 import React, { useContext } from 'react';
-import { StatusAlert } from '@edx/paragon';
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Alert } from '@edx/paragon';
+import { Error } from '@edx/paragon/icons';
 
 import MarkCompleteModalContext from './MarkCompleteModalContext';
 
 const ModalError = () => {
   const { courseLink, courseTitle } = useContext(MarkCompleteModalContext);
   return (
-    <StatusAlert
-      alertType="danger"
-      dialog={(
-        <div className="d-flex">
-          <div>
-            <FontAwesomeIcon className="mr-3" icon={faExclamationTriangle} />
-          </div>
-          <div>
-            Unable to save
-            {' '}
-            <a href={courseLink}>{courseTitle}</a>.
-            {' '}
-            for later. Please try again.
-          </div>
-        </div>
-      )}
-      dismissible={false}
-      open
-    />
+    <Alert variant="danger" icon={Error}>
+      Unable to save <Alert.Link href={courseLink}>{courseTitle}</Alert.Link> for later. Please try again.
+    </Alert>
   );
 };
 

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/ModalError.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/ModalError.jsx
@@ -1,32 +1,15 @@
 import React, { useContext } from 'react';
-import { StatusAlert } from '@edx/paragon';
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Alert } from '@edx/paragon';
+import { Error } from '@edx/paragon/icons';
 
 import MoveToInProgressModalContext from './MoveToInProgressModalContext';
 
 const ModalError = () => {
   const { courseLink, courseTitle } = useContext(MoveToInProgressModalContext);
   return (
-    <StatusAlert
-      alertType="danger"
-      dialog={(
-        <div className="d-flex">
-          <div>
-            <FontAwesomeIcon className="mr-3" icon={faExclamationTriangle} />
-          </div>
-          <div>
-            An error occurred while unarchiving
-            {' '}
-            <a href={courseLink}>{courseTitle}</a>.
-            {' '}
-            Please try again.
-          </div>
-        </div>
-      )}
-      dismissible={false}
-      open
-    />
+    <Alert variant="danger" icon={Error}>
+      An error occurred while unarchiving <Alert.Link href={courseLink}>{courseTitle}</Alert.Link>. Please try again.
+    </Alert>
   );
 };
 

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -10,14 +10,14 @@ import { LoadingSpinner } from '../loading-spinner';
 import NotFoundPage from '../NotFoundPage';
 
 import { isDefined, isDefinedAndNull } from '../../utils/common';
-import {
-  useEnterpriseCustomerConfig,
-} from './data/hooks';
+import { useAlgoliaSearch } from '../../utils/hooks';
+import { useEnterpriseCustomerConfig } from './data/hooks';
 
 export default function EnterprisePage({ children, useEnterpriseConfigCache }) {
   const { enterpriseSlug } = useParams();
   const [enterpriseConfig, fetchError] = useEnterpriseCustomerConfig(enterpriseSlug, useEnterpriseConfigCache);
-
+  const config = getConfig();
+  const [searchClient, searchIndex] = useAlgoliaSearch(config);
   const user = getAuthenticatedUser();
   const { profileImage } = user;
 
@@ -42,7 +42,8 @@ export default function EnterprisePage({ children, useEnterpriseConfigCache }) {
     <AppContext.Provider
       value={{
         authenticatedUser: getAuthenticatedUser(),
-        config: getConfig(),
+        config,
+        enterpriseConfig,
         courseCards: {
           'in-progress': {
             settingsMenu: {
@@ -50,7 +51,10 @@ export default function EnterprisePage({ children, useEnterpriseConfigCache }) {
             },
           },
         },
-        enterpriseConfig,
+        algolia: {
+          client: searchClient,
+          index: searchIndex,
+        },
       }}
     >
       {children}

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -41,7 +41,7 @@ export default function EnterprisePage({ children, useEnterpriseConfigCache }) {
   return (
     <AppContext.Provider
       value={{
-        authenticatedUser: getAuthenticatedUser(),
+        authenticatedUser: user,
         config,
         enterpriseConfig,
         courseCards: {

--- a/src/components/enterprise-page/EnterprisePage.test.jsx
+++ b/src/components/enterprise-page/EnterprisePage.test.jsx
@@ -1,0 +1,84 @@
+import React, { useContext } from 'react';
+import { mount } from 'enzyme';
+import * as auth from '@edx/frontend-platform/auth';
+import { ErrorPage, AppContext } from '@edx/frontend-platform/react';
+
+import EnterprisePage from './EnterprisePage';
+import { LoadingSpinner } from '../loading-spinner';
+import NotFoundPage from '../NotFoundPage';
+import * as hooks from './data/hooks';
+
+const mockUser = {
+  profileImage: 'http://fake.image',
+};
+jest.mock('@edx/frontend-platform/auth');
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn().mockReturnValue({ enterpriseSlug: 'test-enterprise-slug' }),
+}));
+
+describe('<EnterprisePage />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('renders loading state', () => {
+    it('while fetching enterprise config', () => {
+      jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => mockUser);
+      // mock hook as if async call to fetch enterprise config is still resolving
+      jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [undefined, undefined]);
+      const wrapper = mount(<EnterprisePage><div className="did-i-render" /></EnterprisePage>);
+      expect(wrapper.find(LoadingSpinner)).toBeTruthy();
+    });
+    it('while hydrating user metadata', () => {
+      jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => ({}));
+      // mock hook as if async call to fetch enterprise config is fully resolved
+      jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [{}, undefined]);
+      const wrapper = mount(<EnterprisePage><div className="did-i-render" /></EnterprisePage>);
+      expect(wrapper.find(LoadingSpinner)).toBeTruthy();
+    });
+  });
+  it('renders error state when unable to fetch enterprise config', () => {
+    jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => mockUser);
+    // mock hook as if async call to fetch enterprise config is fully resolved
+    jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [null, new Error('test error')]);
+    const wrapper = mount(<EnterprisePage><div className="did-i-render" /></EnterprisePage>);
+    expect(wrapper.find(ErrorPage)).toBeTruthy();
+  });
+  it('renders not found page when no enterprise config is found', () => {
+    jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => mockUser);
+    // mock hook as if async call to fetch enterprise config is fully resolved
+    jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [null, undefined]);
+    const wrapper = mount(<EnterprisePage><div className="did-i-render" /></EnterprisePage>);
+    expect(wrapper.find(NotFoundPage)).toBeTruthy();
+  });
+  it('populates AppContext with expected values', () => {
+    jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => mockUser);
+    const mockEnterpriseConfig = {
+      slug: 'test-slug',
+    };
+    jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [mockEnterpriseConfig, undefined]);
+    const ChildComponent = () => {
+      const contextValue = useContext(AppContext);
+      return <div className="did-i-render" data-contextvalue={contextValue} />;
+    };
+    const wrapper = mount(<EnterprisePage><ChildComponent /></EnterprisePage>);
+    const actualContextValue = wrapper.find('.did-i-render').prop('data-contextvalue');
+    expect(actualContextValue).toEqual(
+      expect.objectContaining({
+        authenticatedUser: mockUser,
+        config: expect.any(Object),
+        enterpriseConfig: mockEnterpriseConfig,
+        courseCards: {
+          'in-progress': {
+            settingsMenu: {
+              hasMarkComplete: true,
+            },
+          },
+        },
+        algolia: {
+          client: expect.any(Object),
+          index: expect.any(Object),
+        },
+      }),
+    );
+  });
+});

--- a/src/components/license-activation/LicenseActivation.jsx
+++ b/src/components/license-activation/LicenseActivation.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { AppContext } from '@edx/frontend-platform/react';
-import { StatusAlert, Container } from '@edx/paragon';
+import { Alert, Container } from '@edx/paragon';
 
 import { LoadingSpinner } from '../loading-spinner';
 import { useLicenseActivation } from './data/hooks';
@@ -35,18 +35,11 @@ export default function LicenseActivation() {
       <>
         <Helmet title={PAGE_TITLE} />
         <Container size="lg" className="mt-3">
-          <StatusAlert
-            alertType="danger"
-            dialog={(
-              <>
-                We were unable to activate a license for this user.
-                {' '}Please double-check that you have a pending license and verify the email to which it was sent.
-                If you run into further issues, please {renderContactHelpText()} for assistance.
-              </>
-            )}
-            dismissible={false}
-            open
-          />
+          <Alert variant="danger">
+            We were unable to activate a license for this user. Please double-check that you have an
+            assigned license and verify the email to which it was sent. If you run into further issues,
+            please {renderContactHelpText(Alert.Link)} for assistance.
+          </Alert>
         </Container>
       </>
     );

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -1,12 +1,11 @@
 import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
-import algoliasearch from 'algoliasearch/lite';
 import { Configure, InstantSearch } from 'react-instantsearch-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/config';
 import { SearchHeader } from '@edx/frontend-enterprise-catalog-search';
-import { useDefaultSearchFilters } from './data/hooks';
 
+import { useDefaultSearchFilters } from './data/hooks';
 import { NUM_RESULTS_PER_PAGE } from './constants';
 import SearchResults from './SearchResults';
 
@@ -14,7 +13,7 @@ import { IntegrationWarningModal } from '../integration-warning-modal';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 
 const Search = () => {
-  const { enterpriseConfig } = useContext(AppContext);
+  const { enterpriseConfig, algolia } = useContext(AppContext);
   const { subscriptionPlan, subscriptionLicense, offers: { offers } } = useContext(UserSubsidyContext);
   const offerCatalogs = offers.map((offer) => offer.catalog);
   const { filters } = useDefaultSearchFilters({
@@ -25,10 +24,6 @@ const Search = () => {
   });
 
   const config = getConfig();
-  const searchClient = algoliasearch(
-    config.ALGOLIA_APP_ID,
-    config.ALGOLIA_SEARCH_API_KEY,
-  );
 
   const PAGE_TITLE = `Search courses - ${enterpriseConfig.name}`;
 
@@ -37,9 +32,13 @@ const Search = () => {
       <Helmet title={PAGE_TITLE} />
       <InstantSearch
         indexName={config.ALGOLIA_INDEX_NAME}
-        searchClient={searchClient}
+        searchClient={algolia.client}
       >
-        <Configure hitsPerPage={NUM_RESULTS_PER_PAGE} filters={filters} />
+        <Configure
+          hitsPerPage={NUM_RESULTS_PER_PAGE}
+          filters={filters}
+          clickAnalytics
+        />
         <div className="search-header-wrapper">
           <SearchHeader containerSize="lg" />
         </div>

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -3,7 +3,7 @@ import algoliasearch from 'algoliasearch';
 
 export const useRenderContactHelpText = (enterpriseConfig) => {
   const renderContactHelpText = useCallback(
-    () => {
+    (LinkComponent = 'a') => {
       const { contactEmail } = enterpriseConfig;
       const message = 'reach out to your organization\'s edX administrator';
 
@@ -11,9 +11,9 @@ export const useRenderContactHelpText = (enterpriseConfig) => {
         return message;
       }
       return (
-        <a href={`mailto:${contactEmail}`}>
+        <LinkComponent href={`mailto:${contactEmail}`}>
           {message}
-        </a>
+        </LinkComponent>
       );
     },
     [enterpriseConfig],

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -1,6 +1,7 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import algoliasearch from 'algoliasearch';
 
-export function useRenderContactHelpText(enterpriseConfig) {
+export const useRenderContactHelpText = (enterpriseConfig) => {
   const renderContactHelpText = useCallback(
     () => {
       const { contactEmail } = enterpriseConfig;
@@ -19,4 +20,19 @@ export function useRenderContactHelpText(enterpriseConfig) {
   );
 
   return renderContactHelpText;
-}
+};
+
+export const useAlgoliaSearch = (config) => {
+  const [searchClient, searchIndex] = useMemo(
+    () => {
+      const client = algoliasearch(
+        config.ALGOLIA_APP_ID,
+        config.ALGOLIA_SEARCH_API_KEY,
+      );
+      const index = client.initIndex(config.ALGOLIA_INDEX_NAME);
+      return [client, index];
+    },
+    [JSON.stringify(config)],
+  );
+  return [searchClient, searchIndex];
+};

--- a/src/utils/tests.jsx
+++ b/src/utils/tests.jsx
@@ -78,6 +78,10 @@ export const initialCourseState = ({
   userEntitlements: [],
   userSubsidyApplicableToCourse,
   catalog: { catalogList: [] },
+  algoliaSearchParams: {
+    queryId: undefined,
+    objectId: undefined,
+  },
 });
 
 export const A_100_PERCENT_OFFER = {


### PR DESCRIPTION
ENT-4549

This PR primarily dispatches Segment events on course search result clicks and enroll button clicks to track Algolia click-thru and conversion rates along with other insights.

I enabled the "Algolia Insights" destination in Segment for the learner portal source and configured it to rename the above custom event names to the Segment spec so they get picked up by Algolia analytics:
* `Product Clicked` (click-thru rate)
* `Order Completed` (conversions)

The following Segment events are added:
* `edx.ui.enterprise.learner_portal.search.card.clicked` (Product Clicked)
* `edx.ui.enterprise.learner_portal.course.enroll_button.to_courseware.clicked` (Order Completed)
* `edx.ui.enterprise.learner_portal.course.enroll_button.to_dsc.clicked` (Order Completed)
* `edx.ui.enterprise.learner_portal.course.enroll_button.to_dashboard.clicked` (Order Completed)
* `edx.ui.enterprise.learner_portal.course.enroll_button.to_ecommerce_basket.clicked` (Order Completed)

Other notable changes in this PR:
* Moves the Algolia search client and index into the `AppContext.Provider` so that it is accessible from anywhere in the app versus only the search page. This may be helpful if/when we decide to show recommended courses from Algolia as "widgets" in other pages beyond the search page itself.
* Swaps out a few `StatusAlert` components in favor of `Alert`
* Upgrades Paragon to latest (v16.3.1) to pull in `Alert` style changes.
* Removes unused `sanitize-html` package.