### PR TITLE
feature: Typeahead algolia skills search dropdown

### DIFF
--- a/src/components/skills-quiz/SkillsQuiz.jsx
+++ b/src/components/skills-quiz/SkillsQuiz.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
+import { SearchData } from '@edx/frontend-enterprise-catalog-search';
 
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -20,7 +21,9 @@ const SkillsQuiz = () => {
       <Container size="lg" className="py-5">
         <Row>
           <MainContent>
-            <SkillsQuizStepper />
+            <SearchData>
+              <SkillsQuizStepper />
+            </SearchData>
           </MainContent>
         </Row>
 

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -5,7 +5,8 @@ import {
 import algoliasearch from 'algoliasearch/lite';
 import { Configure, InstantSearch } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';
-import { SearchContext, FacetListRefinement } from '@edx/frontend-enterprise-catalog-search';
+import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
+import FacetListRefinement from '@edx/frontend-enterprise-catalog-search/FacetListRefinement';
 import { NUM_RESULTS_PER_PAGE } from '../search/constants';
 
 import GoalDropdown from './GoalDropdown';

--- a/src/components/skills-quiz/__mocks__/react-instantsearch-dom.jsx
+++ b/src/components/skills-quiz/__mocks__/react-instantsearch-dom.jsx
@@ -1,0 +1,71 @@
+/* eslint-disable object-curly-newline */
+/* eslint-disable react/prop-types */
+import React from 'react';
+
+const MockReactInstantSearch = jest.genMockFromModule(
+  'react-instantsearch-dom',
+);
+
+// eslint-disable-next-line camelcase
+const advertised_course_run = {
+  start: '2020-09-09T04:00:00Z',
+  key: 'course-v1:edX+Bee101+3T2020',
+};
+
+const fakeHits = [
+  { objectID: '1', title: 'bla', advertised_course_run, key: 'Bees101' },
+  { objectID: '2', title: 'blp', advertised_course_run, key: 'Wasps200' },
+];
+
+MockReactInstantSearch.connectStateResults = Component => (props) => (
+  <Component
+    searchResults={{
+      hits: fakeHits,
+      hitsPerPage: 25,
+      nbHits: 2,
+      nbPages: 1,
+      page: 1,
+    }}
+    isSearchStalled={false}
+    searchState={{
+      page: 1,
+    }}
+    {...props}
+  />
+);
+
+MockReactInstantSearch.connectPagination = Component => (props) => (
+  <Component nbPages={2} maxPagesDisplayed={2} {...props} />
+);
+
+MockReactInstantSearch.InstantSearch = ({ children }) => <div>{children}</div>;
+
+MockReactInstantSearch.connectCurrentRefinements = Component => (props) => (
+  <Component items={[]} {...props} />
+);
+
+MockReactInstantSearch.connectRefinementList = Component => (props) => (
+  <Component
+    attribute="subjects"
+    currentRefinement={[]}
+    items={[]}
+    refinementsFromQueryParams={{}}
+    title="Foo"
+    searchForItems={() => {}}
+    {...props}
+  />
+);
+
+MockReactInstantSearch.connectSearchBox = Component => (props) => (
+  <Component {...props} />
+);
+
+MockReactInstantSearch.connectPagination = Component => (props) => (
+  <Component nbPages={1} {...props} />
+);
+
+MockReactInstantSearch.InstantSearch = ({ children }) => <>{children}</>;
+MockReactInstantSearch.Configure = () => <div>CONFIGURED</div>;
+
+// It is necessary to export this way, or tests not using the mock will fail
+module.exports = MockReactInstantSearch;

--- a/src/components/skills-quiz/constants.js
+++ b/src/components/skills-quiz/constants.js
@@ -3,3 +3,15 @@ export const DROPDOWN_OPTION_CHANGE_CAREERS = 'I want to change careers';
 export const DROPDOWN_OPTION_GET_PROMOTED = 'I want to get promoted';
 export const DROPDOWN_OPTION_CHANGE_ROLE = 'I want to get better at my current role';
 export const DROPDOWN_OPTION_OTHER = 'Other';
+
+export const SKILLS_QUIZ_FACET_FILTERS = [
+  {
+    attribute: 'skill_names',
+    title: 'Skills',
+    typeaheadOptions: {
+      placeholder: 'Find a skill...',
+      ariaLabel: 'Type to find a skill',
+      minLength: 3,
+    },
+  },
+];

--- a/src/components/skills-quiz/tests/SearchFilters.test.jsx
+++ b/src/components/skills-quiz/tests/SearchFilters.test.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { SKILLS_QUIZ_FACET_FILTERS } from '../constants';
+
+import { renderWithSearchContext } from './utils';
+
+import '../__mocks__/react-instantsearch-dom';
+import SkillsQuizStepper from '../SkillsQuizStepper';
+
+describe('<SkillsQuizStepper />', () => {
+  test('renders with a label', () => {
+    renderWithSearchContext(<SkillsQuizStepper />);
+    SKILLS_QUIZ_FACET_FILTERS.forEach((filter) => {
+      expect(screen.getByText(filter.title)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/skills-quiz/tests/SkillsQuiz.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuiz.test.jsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Provider as ReduxProvider } from 'react-redux';
+import { SearchData } from '@edx/frontend-enterprise-catalog-search';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 
 import {
@@ -73,7 +74,9 @@ describe('<SkillsQuiz />', () => {
   it('renders skills quiz page successfully.', () => {
     const SILLS_QUIZ_PAGE_MESSAGE = 'edX is here to help you find the course(s) or program(s) to help you take the next step in your career. Tell us a bit about your current role, and skills or jobs you\'re interested in.';
     renderWithRouter(
-      <SkillsQuizWithContext initialAppState={initialAppState} initialUserSubsidyState={initialUserSubsidyState} />,
+      <SearchData>
+        <SkillsQuizWithContext initialAppState={initialAppState} initialUserSubsidyState={initialUserSubsidyState} />
+      </SearchData>,
       { route: '/test/skills-quiz/' },
     );
     expect(screen.getByText('Skills Quiz')).toBeTruthy();

--- a/src/components/skills-quiz/tests/utils.jsx
+++ b/src/components/skills-quiz/tests/utils.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+
+import { SearchData } from '@edx/frontend-enterprise-catalog-search';
+
+// eslint-disable-next-line import/prefer-default-export
+export const renderWithSearchContext = (children) => renderWithRouter(
+  <SearchData>
+    {children}
+  </SearchData>,
+);


### PR DESCRIPTION
[ENT4670](https://openedx.atlassian.net/browse/ENT-4670): Dropdown for selecting relevant skills is added in this PR. All the skills selected are added in URL as query param and can be accessed through Context. Styling of the component is not covered in this PR.
<img width="1676" alt="Screenshot 2021-07-24 at 3 27 54 PM" src="https://user-images.githubusercontent.com/11922730/126947727-de4738f3-217c-408a-87eb-2c8fc11c9c87.png">

