### PR TITLE
feat((learner_portal)): :sparkles: Use config to hide expiration modals

### DIFF
--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -18,7 +18,7 @@ export const LICENCE_ACTIVATION_MESSAGE = 'Your license has been successfully ac
 
 export default function Dashboard() {
   const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionPlan } = useContext(UserSubsidyContext);
+  const { subscriptionPlan, showExpirationNotifications } = useContext(UserSubsidyContext);
   const { state } = useLocation();
   const [isActivationAlertOpen, , closeActivationAlert] = useToggle(!!state?.activationSuccess);
 
@@ -29,7 +29,6 @@ export default function Dashboard() {
   );
 
   const PAGE_TITLE = `Dashboard - ${enterpriseConfig.name}`;
-
   return (
     <>
       <Helmet title={PAGE_TITLE} />
@@ -47,7 +46,7 @@ export default function Dashboard() {
             )}
           </MediaQuery>
           <IntegrationWarningModal isOpen={enterpriseConfig.showIntegrationWarning} />
-          {subscriptionPlan && <SubscriptionExpirationModal />}
+          {subscriptionPlan && showExpirationNotifications && <SubscriptionExpirationModal />}
         </Row>
       </Container>
     </>

--- a/src/components/dashboard/tests/Dashboard.test.jsx
+++ b/src/components/dashboard/tests/Dashboard.test.jsx
@@ -154,6 +154,7 @@ describe('<Dashboard />', () => {
         ...mockSubscriptionPlan,
         daysUntilExpiration: 60,
       },
+      showExpirationNotifications: true,
     };
     renderWithRouter(
       <DashboardWithContext
@@ -166,6 +167,26 @@ describe('<Dashboard />', () => {
     expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
   });
 
+  it('does not render the modals when 60 >= daysUntilExpiration > 0 and expiration messages are disabled', () => {
+    const expiringSubscriptionUserSubsidyState = {
+      ...initialUserSubsidyState,
+      subscriptionPlan: {
+        ...mockSubscriptionPlan,
+        daysUntilExpiration: 60,
+      },
+      showExpirationNotifications: false,
+    };
+    renderWithRouter(
+      <DashboardWithContext
+        initialAppState={initialAppState}
+        initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        initialCourseState={initialCourseState}
+      />,
+    );
+    expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
+    expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+  });
+
   it('renders the subscription expired modal when 0 >= daysUntilExpiration', () => {
     const expiringSubscriptionUserSubsidyState = {
       ...initialUserSubsidyState,
@@ -173,6 +194,7 @@ describe('<Dashboard />', () => {
         ...mockSubscriptionPlan,
         daysUntilExpiration: 0,
       },
+      showExpirationNotifications: true,
     };
     renderWithRouter(
       <DashboardWithContext
@@ -183,6 +205,26 @@ describe('<Dashboard />', () => {
     );
     expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
     expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeTruthy();
+  });
+
+  it('does not render the modals when 0 >= daysUntilExpiration and expiration messages are disabled ', () => {
+    const expiringSubscriptionUserSubsidyState = {
+      ...initialUserSubsidyState,
+      subscriptionPlan: {
+        ...mockSubscriptionPlan,
+        daysUntilExpiration: 0,
+      },
+      showExpirationNotifications: false,
+    };
+    renderWithRouter(
+      <DashboardWithContext
+        initialAppState={initialAppState}
+        initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        initialCourseState={initialCourseState}
+      />,
+    );
+    expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
+    expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
   });
 
   it('renders a sidebar on a large screen', () => {

--- a/src/components/enterprise-user-subsidy/UserSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidy.jsx
@@ -10,6 +10,7 @@ import { LoadingSpinner } from '../loading-spinner';
 import {
   useSubscriptionLicenseForUser,
   useOffers,
+  useCustomerAgreementData,
 } from './data/hooks';
 import { LICENSE_STATUS, LOADING_SCREEN_READER_TEXT } from './data/constants';
 
@@ -18,22 +19,25 @@ export const UserSubsidyContext = createContext();
 const UserSubsidy = ({ children }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const [subscriptionLicense, isLoadingLicense] = useSubscriptionLicenseForUser(enterpriseConfig.uuid);
+  const [customerAgreementConfig, isLoadingCustomerAgreementConfig] = useCustomerAgreementData(enterpriseConfig.uuid);
   const [offers, isLoadingOffers] = useOffers(enterpriseConfig.uuid);
   const [subscriptionPlan, setSubscriptionPlan] = useState();
+  const [showExpirationNotifications, setShowExpirationNotifications] = useState();
 
   useEffect(
     () => {
       setSubscriptionPlan(subscriptionLicense?.subscriptionPlan);
+      setShowExpirationNotifications(!(customerAgreementConfig?.disableExpirationNotifications));
     },
-    [subscriptionLicense],
+    [subscriptionLicense, customerAgreementConfig],
   );
 
   const isLoadingSubsidies = useMemo(
     () => {
-      const loadingStates = [isLoadingLicense, isLoadingOffers];
+      const loadingStates = [isLoadingLicense, isLoadingOffers, isLoadingCustomerAgreementConfig];
       return loadingStates.includes(true);
     },
-    [isLoadingLicense, isLoadingOffers],
+    [isLoadingLicense, isLoadingOffers, isLoadingCustomerAgreementConfig],
   );
 
   const contextValue = useMemo(
@@ -53,9 +57,15 @@ const UserSubsidy = ({ children }) => {
         subscriptionLicense,
         subscriptionPlan,
         offers,
+        showExpirationNotifications,
       };
     },
-    [isLoadingSubsidies, subscriptionPlan, subscriptionLicense, offers, enterpriseConfig?.uuid],
+    [isLoadingSubsidies,
+      subscriptionPlan,
+      subscriptionLicense,
+      offers,
+      enterpriseConfig?.uuid,
+      customerAgreementConfig],
   );
 
   if (isLoadingSubsidies) {

--- a/src/components/enterprise-user-subsidy/data/hooks.jsx
+++ b/src/components/enterprise-user-subsidy/data/hooks.jsx
@@ -10,6 +10,7 @@ import offersReducer, { initialOfferState } from '../offers/data/reducer';
 import { LICENSE_STATUS } from './constants';
 import {
   fetchSubscriptionLicensesForUser,
+  fetchCustomerAgreementData,
 } from './service';
 import { features } from '../../../config';
 
@@ -65,4 +66,29 @@ export function useOffers(enterpriseId) {
   );
 
   return [offerState, offerState.loading];
+}
+
+export function useCustomerAgreementData(enterpriseId) {
+  const [customerAgreement, setCustomerAgreement] = useState();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetchCustomerAgreementData(enterpriseId)
+      .then((response) => {
+        const { results } = camelCaseObject(response.data);
+        // Note: customer agreements are unique, only 1 can exist per customer
+        if (results.length) {
+          setCustomerAgreement(results[0]);
+        }
+      })
+      .catch((error) => {
+        logError(new Error(error));
+        setCustomerAgreement(null);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [enterpriseId]);
+
+  return [customerAgreement, isLoading];
 }

--- a/src/components/enterprise-user-subsidy/data/service.js
+++ b/src/components/enterprise-user-subsidy/data/service.js
@@ -10,3 +10,13 @@ export function fetchSubscriptionLicensesForUser(enterpriseUUID) {
   const url = `${config.LICENSE_MANAGER_URL}/api/v1/learner-licenses/?${qs.stringify(queryParams)}`;
   return getAuthenticatedHttpClient().get(url);
 }
+
+export function fetchCustomerAgreementData(enterpriseUUID) {
+  const queryParams = {
+    enterprise_customer_uuid: enterpriseUUID,
+
+  };
+  const config = getConfig();
+  const url = `${config.LICENSE_MANAGER_URL}/api/v1/customer-agreement/?${qs.stringify(queryParams)}`;
+  return getAuthenticatedHttpClient().get(url);
+}

--- a/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/UserSubsidy.test.jsx
@@ -10,6 +10,7 @@ import { renderWithRouter } from '../../../utils/tests';
 import { LICENSE_STATUS, LOADING_SCREEN_READER_TEXT } from '../data/constants';
 import {
   fetchSubscriptionLicensesForUser,
+  fetchCustomerAgreementData,
 } from '../data/service';
 import { fetchOffers } from '../offers/data/service';
 
@@ -29,6 +30,15 @@ const mockSubscriptionPlan = {
   isActive: true,
   startDate: moment().subtract(1, 'w').toISOString(),
   expirationDate: moment().add(1, 'y').toISOString(),
+};
+
+const mockCustomerAgreementData = {
+  data: {
+    count: 1,
+    results: [{
+      disableExpirationNotifications: false,
+    }],
+  },
 };
 
 // eslint-disable-next-line react/prop-types
@@ -74,6 +84,7 @@ describe('UserSubsidy', () => {
       };
       fetchOffers.mockResolvedValueOnce(response);
       fetchSubscriptionLicensesForUser.mockResolvedValueOnce(response);
+      fetchCustomerAgreementData.mockResolvedValueOnce(response);
     });
 
     afterEach(() => {
@@ -123,6 +134,7 @@ describe('UserSubsidy', () => {
         },
       };
       fetchSubscriptionLicensesForUser.mockResolvedValueOnce(response);
+      fetchCustomerAgreementData.mockResolvedValueOnce(response);
       const Component = (
         <UserSubsidyWithAppContext>
           <HasAccessConsumer />
@@ -132,6 +144,7 @@ describe('UserSubsidy', () => {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+      expect(fetchCustomerAgreementData).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledWith({
         enterprise_uuid: TEST_ENTERPRISE_UUID,
         full_discount_only: 'True',
@@ -151,6 +164,7 @@ describe('UserSubsidy', () => {
           }],
         },
       });
+      fetchCustomerAgreementData.mockResolvedValueOnce(mockCustomerAgreementData);
       const Component = (
         <UserSubsidyWithAppContext>
           <HasAccessConsumer />
@@ -160,6 +174,7 @@ describe('UserSubsidy', () => {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+      expect(fetchCustomerAgreementData).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledWith({
         enterprise_uuid: TEST_ENTERPRISE_UUID,
         full_discount_only: 'True',
@@ -181,6 +196,7 @@ describe('UserSubsidy', () => {
           }],
         },
       });
+      fetchCustomerAgreementData.mockResolvedValueOnce(mockCustomerAgreementData);
       const Component = (
         <UserSubsidyWithAppContext>
           <SubscriptionLicenseConsumer />
@@ -190,6 +206,7 @@ describe('UserSubsidy', () => {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+      expect(fetchCustomerAgreementData).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledWith({
         enterprise_uuid: TEST_ENTERPRISE_UUID,
         full_discount_only: 'True',
@@ -211,6 +228,8 @@ describe('UserSubsidy', () => {
           }],
         },
       });
+      fetchCustomerAgreementData.mockResolvedValueOnce(mockCustomerAgreementData);
+
       const Component = (
         <UserSubsidyWithAppContext>
           <OffersConsumer />
@@ -220,6 +239,7 @@ describe('UserSubsidy', () => {
         route: `/${TEST_ENTERPRISE_SLUG}`,
       });
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+      expect(fetchCustomerAgreementData).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
       expect(fetchOffers).toHaveBeenCalledTimes(1);
       expect(fetchOffers).toHaveBeenCalledWith({ enterprise_uuid: TEST_ENTERPRISE_UUID, full_discount_only: 'True', is_active: 'True' });
 
@@ -240,6 +260,7 @@ describe('UserSubsidy', () => {
           }],
         },
       });
+      fetchCustomerAgreementData.mockResolvedValueOnce(mockCustomerAgreementData);
       fetchOffers.mockResolvedValueOnce({
         data: {
           count: 0,
@@ -262,6 +283,7 @@ describe('UserSubsidy', () => {
           }],
         },
       });
+      fetchCustomerAgreementData.mockResolvedValueOnce(mockCustomerAgreementData);
 
       const Component = (
         <UserSubsidyWithAppContext>
@@ -276,6 +298,7 @@ describe('UserSubsidy', () => {
       expect(screen.getByText(LOADING_SCREEN_READER_TEXT)).toBeInTheDocument();
 
       expect(fetchSubscriptionLicensesForUser).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+      expect(fetchCustomerAgreementData).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
 
       await waitFor(() => {
         expect(screen.getByTestId('did-i-render')).toBeInTheDocument();


### PR DESCRIPTION
ENT-4544. Use the CustomerAgreement API to determine if we should show or hide expiration modals. This is designed to be used with Trials, where the fact that a Trial will expire in 14 days isn't something that needs giant modal warnings about during the experience.