### PR TITLE
feat: handle multiple course enrollment failure reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "universal-cookie": "4.0.4"
   },
   "devDependencies": {
-    "@edx/frontend-build": "^8.0.4",
+    "@edx/frontend-build": "8.0.4",
     "@testing-library/jest-dom": "5.11.9",
     "@testing-library/react": "11.2.5",
     "@testing-library/react-hooks": "3.7.0",

--- a/src/components/course/CourseEnrollmentFailedAlert.jsx
+++ b/src/components/course/CourseEnrollmentFailedAlert.jsx
@@ -1,0 +1,61 @@
+import React, { useContext, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { AppContext } from '@edx/frontend-platform/react';
+import { Container, Alert } from '@edx/paragon';
+
+import { useRenderContactHelpText } from '../../utils/hooks';
+import {
+  ENROLLMENT_FAILED_QUERY_PARAM,
+  ENROLLMENT_FAILURE_REASON_QUERY_PARAM,
+} from './data/constants';
+
+/**
+ * A component to render an alert when a learner fails to enroll in a course for any number of
+ * reasons. The contents of the alert are determined by a ``failureReason`` which is passed
+ * from the Data Sharing Consent (DSC) page as a query parameter.
+ */
+const CourseEnrollmentFailedAlert = () => {
+  const { enterpriseConfig } = useContext(AppContext);
+  const renderContactHelpText = useRenderContactHelpText(enterpriseConfig);
+
+  const { search } = useLocation();
+  const [hasEnrollmentFailed, failureReason] = useMemo(
+    () => {
+      const searchParams = new URLSearchParams(search);
+      return [
+        searchParams.get(ENROLLMENT_FAILED_QUERY_PARAM),
+        searchParams.get(ENROLLMENT_FAILURE_REASON_QUERY_PARAM),
+      ];
+    },
+    [search],
+  );
+
+  const failureReasonMessages = {
+    dsc_denied: (
+      <>
+        You were not enrolled in your selected course. In order to enroll, you must accept the data sharing
+        consent terms. Please {renderContactHelpText(Alert.Link)} for further information.
+      </>
+    ),
+    verified_mode_unavailable: (
+      <>
+        You were not enrolled in your selected course as the verified course mode is
+        unavailable. Please {renderContactHelpText(Alert.Link)} for further information.
+      </>
+    ),
+  };
+
+  if (!hasEnrollmentFailed || !failureReasonMessages[failureReason]) {
+    return null;
+  }
+
+  return (
+    <Container size="lg" className="pt-3">
+      <Alert variant="danger">
+        {failureReasonMessages[failureReason]}
+      </Alert>
+    </Container>
+  );
+};
+
+export default CourseEnrollmentFailedAlert;

--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -1,6 +1,11 @@
 import React, { useContext, useMemo } from 'react';
 import classNames from 'classnames';
-import { Breadcrumb, Container, Row, Col } from '@edx/paragon';
+import {
+  Breadcrumb,
+  Container,
+  Row,
+  Col,
+} from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { CourseContext } from './CourseContextProvider';

--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react';
 import classNames from 'classnames';
-import { Breadcrumb, Container } from '@edx/paragon';
+import { Breadcrumb, Container, Row, Col } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { CourseContext } from './CourseContextProvider';
@@ -35,8 +35,8 @@ export default function CourseHeader() {
     <div className="course-header">
       <CourseEnrollmentFailedAlert />
       <Container size="lg">
-        <div className="row py-4">
-          <div className="col-12 col-lg-7">
+        <Row className="py-4">
+          <Col xs={12} lg={7}>
             {primarySubject && (
               <div className="small">
                 <Breadcrumb
@@ -100,13 +100,13 @@ export default function CourseHeader() {
                 This course is not part of your company&apos;s curated course catalog.
               </p>
             )}
-          </div>
+          </Col>
           {course.image?.src && (
-            <div className="col-12 col-lg-4 offset-lg-1 mt-3 mt-lg-0">
+            <Col xs={12} lg={{ span: 4, offset: 1 }} className="mt-3 mt-lg-0">
               <img src={course.image.src} alt="course preview" className="w-100" />
-            </div>
+            </Col>
           )}
-        </div>
+        </Row>
       </Container>
     </div>
   );

--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -1,6 +1,5 @@
 import React, { useContext, useMemo } from 'react';
 import classNames from 'classnames';
-import { useLocation } from 'react-router-dom';
 import { Breadcrumb, Container } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -8,11 +7,8 @@ import { CourseContext } from './CourseContextProvider';
 import CourseRunSelector from './CourseRunSelector';
 import CourseSkills from './CourseSkills';
 import EnrollButton from './EnrollButton';
+import CourseEnrollmentFailedAlert from './CourseEnrollmentFailedAlert';
 
-import {
-  ENROLLMENT_FAILED_QUERY_PARAM,
-  ENROLLMENT_FAILURE_REASON_QUERY_PARAM,
-} from './data/constants';
 import {
   isArchived,
   getDefaultProgram,
@@ -21,7 +17,6 @@ import {
 import {
   useCourseSubjects,
   useCoursePartners,
-  useRenderFailedEnrollmentAlert,
 } from './data/hooks';
 
 export default function CourseHeader() {
@@ -36,17 +31,9 @@ export default function CourseHeader() {
     [course],
   );
 
-  const { search } = useLocation();
-  const searchParams = new URLSearchParams(search);
-  const renderFailedEnrollmentAlert = useRenderFailedEnrollmentAlert({
-    enterpriseConfig,
-    isEnrollmentFailed: searchParams.get(ENROLLMENT_FAILED_QUERY_PARAM),
-    failureReasonSlug: searchParams.get(ENROLLMENT_FAILURE_REASON_QUERY_PARAM),
-  });
-
   return (
     <div className="course-header">
-      {renderFailedEnrollmentAlert()}
+      <CourseEnrollmentFailedAlert />
       <Container size="lg">
         <div className="row py-4">
           <div className="col-12 col-lg-7">

--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -53,3 +53,4 @@ export const COURSE_MODES_MAP = {
 };
 
 export const ENROLLMENT_FAILED_QUERY_PARAM = 'enrollment_failed';
+export const ENROLLMENT_FAILURE_REASON_QUERY_PARAM = 'failure_reason';

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   useEffect, useState, useMemo, useContext, useCallback,
 } from 'react';
 import qs from 'query-string';
@@ -8,12 +8,15 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { getConfig } from '@edx/frontend-platform/config';
+import { Container, Alert } from '@edx/paragon';
 
 import { UserSubsidyContext } from '../../enterprise-user-subsidy/UserSubsidy';
+import { CourseContext } from '../CourseContextProvider';
 
 import { isDefinedAndNotNull } from '../../../utils/common';
+import { useRenderContactHelpText } from '../../../utils/hooks';
+import { features } from '../../../config';
 import CourseService from './service';
-import { CourseContext } from '../CourseContextProvider';
 import {
   isCourseInstructorPaced,
   isCourseSelfPaced,
@@ -26,7 +29,6 @@ import {
   CURRENCY_USD,
   ENROLLMENT_FAILED_QUERY_PARAM,
 } from './constants';
-import { features } from '../../../config';
 
 export function useAllCourseData({ courseKey, enterpriseConfig, courseRunKey }) {
   const [courseData, setCourseData] = useState();
@@ -406,4 +408,61 @@ export const useTrackSearchConversionClickHandler = ({ href, eventName }) => {
   );
 
   return handleClick;
+};
+
+/**
+ * A React hook to render an alert when a learner fails to enroll in a course for any number of
+ * reasons. Thecontents of the alert are determined by a ``failureReasonSlug`` which is passed
+ * from the Data Sharing Consent page.
+ *
+ * @param {object} args
+ * @param {object} args.enterpriseConfig Details about the learner's enterprise customer.
+ * @param {boolean} args.isEnrollmentFailed Whether learner's enrollment failed due to an error
+ * @param {boolean} args.failureReasonSlug The lookup key for the reason why the enrollment
+ *  failed; used to determine the appropriate messaging to show in the alert.
+ *
+ * @returns Function to render the alert.
+ */
+export const useRenderFailedEnrollmentAlert = ({
+  enterpriseConfig,
+  isEnrollmentFailed,
+  failureReasonSlug,
+}) => {
+  const renderContactHelpText = useRenderContactHelpText(enterpriseConfig);
+
+  const renderFailedEnrollmentAlert = useCallback(
+    () => {
+      // map alert contents to specific enrollment failure reasons based on the failure reason
+      // slug provided by the Data Sharing Consent (DSC) page.
+      const failureMessagesBySlug = {
+        dsc_denied: (
+          <>
+            You were not enrolled in your selected course. In order to enroll, you must accept the data sharing
+            consent terms. Please {renderContactHelpText(Alert.Link)} for further information.
+          </>
+        ),
+        verification_deadline: (
+          <>
+            You were not enrolled in your selected course as the verification deadline has
+            passed. Please {renderContactHelpText(Alert.Link)} for further information.
+          </>
+        ),
+      };
+
+      if (!isEnrollmentFailed || !failureReasonSlug || !failureMessagesBySlug[failureReasonSlug]) {
+        return null;
+      }
+
+      return (
+        <Container size="lg" className="pt-3">
+          <Alert variant="danger">
+            {failureMessagesBySlug[failureReasonSlug]}
+          </Alert>
+        </Container>
+      );
+    },
+    [enterpriseConfig, isEnrollmentFailed, failureReasonSlug],
+  );
+
+  return renderFailedEnrollmentAlert;
 };

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -449,7 +449,7 @@ export const useRenderFailedEnrollmentAlert = ({
         ),
       };
 
-      if (!isEnrollmentFailed || !failureReasonSlug || !failureMessagesBySlug[failureReasonSlug]) {
+      if (!isEnrollmentFailed || !failureMessagesBySlug[failureReasonSlug]) {
         return null;
       }
 

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useEffect, useState, useMemo, useContext, useCallback,
 } from 'react';
 import qs from 'query-string';
@@ -8,13 +8,11 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { getConfig } from '@edx/frontend-platform/config';
-import { Container, Alert } from '@edx/paragon';
 
 import { UserSubsidyContext } from '../../enterprise-user-subsidy/UserSubsidy';
 import { CourseContext } from '../CourseContextProvider';
 
 import { isDefinedAndNotNull } from '../../../utils/common';
-import { useRenderContactHelpText } from '../../../utils/hooks';
 import { features } from '../../../config';
 import CourseService from './service';
 import {
@@ -408,61 +406,4 @@ export const useTrackSearchConversionClickHandler = ({ href, eventName }) => {
   );
 
   return handleClick;
-};
-
-/**
- * A React hook to render an alert when a learner fails to enroll in a course for any number of
- * reasons. The contents of the alert are determined by a ``failureReasonSlug`` which is passed
- * from the Data Sharing Consent (DSC) page.
- *
- * @param {object} args
- * @param {object} args.enterpriseConfig Details about the learner's enterprise customer.
- * @param {boolean} args.isEnrollmentFailed Whether learner's enrollment failed due to an error
- * @param {boolean} args.failureReasonSlug The lookup key for the reason why the enrollment
- *  failed; used to determine the appropriate messaging to show in the alert.
- *
- * @returns Function to render the alert.
- */
-export const useRenderFailedEnrollmentAlert = ({
-  enterpriseConfig,
-  isEnrollmentFailed,
-  failureReasonSlug,
-}) => {
-  const renderContactHelpText = useRenderContactHelpText(enterpriseConfig);
-
-  const renderFailedEnrollmentAlert = useCallback(
-    () => {
-      // map alert contents to specific enrollment failure reasons based on the failure reason
-      // slug provided by the Data Sharing Consent (DSC) page.
-      const failureMessagesBySlug = {
-        dsc_denied: (
-          <>
-            You were not enrolled in your selected course. In order to enroll, you must accept the data sharing
-            consent terms. Please {renderContactHelpText(Alert.Link)} for further information.
-          </>
-        ),
-        verified_mode_unavailable: (
-          <>
-            You were not enrolled in your selected course as the verified course mode is
-            unavailable. Please {renderContactHelpText(Alert.Link)} for further information.
-          </>
-        ),
-      };
-
-      if (!isEnrollmentFailed || !failureMessagesBySlug[failureReasonSlug]) {
-        return null;
-      }
-
-      return (
-        <Container size="lg" className="pt-3">
-          <Alert variant="danger">
-            {failureMessagesBySlug[failureReasonSlug]}
-          </Alert>
-        </Container>
-      );
-    },
-    [enterpriseConfig, isEnrollmentFailed, failureReasonSlug],
-  );
-
-  return renderFailedEnrollmentAlert;
 };

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -441,10 +441,10 @@ export const useRenderFailedEnrollmentAlert = ({
             consent terms. Please {renderContactHelpText(Alert.Link)} for further information.
           </>
         ),
-        verification_deadline: (
+        verified_mode_unavailable: (
           <>
-            You were not enrolled in your selected course as the verification deadline has
-            passed. Please {renderContactHelpText(Alert.Link)} for further information.
+            You were not enrolled in your selected course as the verified course mode is
+            unavailable. Please {renderContactHelpText(Alert.Link)} for further information.
           </>
         ),
       };

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -412,8 +412,8 @@ export const useTrackSearchConversionClickHandler = ({ href, eventName }) => {
 
 /**
  * A React hook to render an alert when a learner fails to enroll in a course for any number of
- * reasons. Thecontents of the alert are determined by a ``failureReasonSlug`` which is passed
- * from the Data Sharing Consent page.
+ * reasons. The contents of the alert are determined by a ``failureReasonSlug`` which is passed
+ * from the Data Sharing Consent (DSC) page.
  *
  * @param {object} args
  * @param {object} args.enterpriseConfig Details about the learner's enterprise customer.

--- a/src/components/course/tests/CourseHeader.test.jsx
+++ b/src/components/course/tests/CourseHeader.test.jsx
@@ -210,9 +210,9 @@ describe('<CourseHeader />', () => {
   );
 
   test.each`
-    enrollmentFailed  | failureReason               | expectedMessage
-    ${'true'}         | ${'dsc_denied'}             | ${'accept the data sharing consent'}
-    ${'true'}         | ${'verification_deadline'}  | ${'verification deadline has passed'}
+    enrollmentFailed  | failureReason                   | expectedMessage
+    ${'true'}         | ${'dsc_denied'}                 | ${'accept the data sharing consent'}
+    ${'true'}         | ${'verified_mode_unavailable'}  | ${'verified course mode is unavailable'}
   `(
     'renders $failureReason alert with `enrollment_failed=$enrollmentFailed` and `failure_reason=$failureReason`',
     ({ enrollmentFailed, failureReason, expectedMessage }) => {

--- a/src/components/course/tests/CourseHeader.test.jsx
+++ b/src/components/course/tests/CourseHeader.test.jsx
@@ -206,7 +206,7 @@ describe('<CourseHeader />', () => {
         />,
       );
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-    }
+    },
   );
 
   test.each`
@@ -229,7 +229,7 @@ describe('<CourseHeader />', () => {
       );
       expect(screen.queryByRole('alert')).toBeInTheDocument();
       expect(screen.queryByText(expectedMessage, { exact: false })).toBeInTheDocument();
-    }
+    },
   );
 
   describe('renders program messaging', () => {

--- a/src/components/course/tests/CourseHeader.test.jsx
+++ b/src/components/course/tests/CourseHeader.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
+import { useLocation } from 'react-router-dom';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -11,9 +12,10 @@ import { COURSE_AVAILABILITY_MAP, COURSE_PACING_MAP } from '../data/constants';
 import { TEST_OWNER } from './data/constants';
 
 jest.mock('react-router-dom', () => ({
-  useLocation: () => ({
-    search: '?enrollment_failed=true',
-  }),
+  useLocation: jest.fn(),
+}));
+useLocation.mockImplementation(() => ({
+  search: '',
 }));
 
 // Stub out the enroll button to avoid testing its implementation here
@@ -36,8 +38,6 @@ const CourseHeaderWithContext = ({
 /* eslint-enable react/prop-types */
 
 describe('<CourseHeader />', () => {
-  // eslint-disable-next-line no-unused-vars
-  let useDispatchSpy;
   const initialAppState = {
     enterpriseConfig: {
       slug: 'test-enterprise-slug',
@@ -186,17 +186,51 @@ describe('<CourseHeader />', () => {
     expect(screen.queryByText('Enroll')).not.toBeInTheDocument();
   });
 
-  test('renders an enrollment failed status alert when the enrollment failed query param is present', () => {
-    render(
-      <CourseHeaderWithContext
-        initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
-        initialUserSubsidyState={initialUserSubsidyState}
-      />,
-    );
+  test.each`
+    enrollmentFailed  | failureReason
+    ${''}             | ${''}
+    ${'true'}         | ${''}
+    ${''}             | ${'dsc_denied'}
+  `(
+    'does not render alert when `enrollment_failed=$enrollmentFailed` or `failure_reason=$failureReason`',
+    ({ enrollmentFailed, failureReason }) => {
+      useLocation.mockImplementation(() => ({
+        search: `?enrollment_failed=${enrollmentFailed}&failure_reason=${failureReason}`,
+      }));
 
-    expect(screen.queryByRole('alert')).toBeInTheDocument();
-  });
+      render(
+        <CourseHeaderWithContext
+          initialAppState={initialAppState}
+          initialCourseState={initialCourseState}
+          initialUserSubsidyState={initialUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    }
+  );
+
+  test.each`
+    enrollmentFailed  | failureReason               | expectedMessage
+    ${'true'}         | ${'dsc_denied'}             | ${'accept the data sharing consent'}
+    ${'true'}         | ${'verification_deadline'}  | ${'verification deadline has passed'}
+  `(
+    'renders $failureReason alert with `enrollment_failed=$enrollmentFailed` and `failure_reason=$failureReason`',
+    ({ enrollmentFailed, failureReason, expectedMessage }) => {
+      useLocation.mockImplementation(() => ({
+        search: `?enrollment_failed=${enrollmentFailed}&failure_reason=${failureReason}`,
+      }));
+
+      render(
+        <CourseHeaderWithContext
+          initialAppState={initialAppState}
+          initialCourseState={initialCourseState}
+          initialUserSubsidyState={initialUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByRole('alert')).toBeInTheDocument();
+      expect(screen.queryByText(expectedMessage, { exact: false })).toBeInTheDocument();
+    }
+  );
 
   describe('renders program messaging', () => {
     const courseStateWithProgramType = (type) => ({


### PR DESCRIPTION
[ENT-4564](https://openedx.atlassian.net/browse/ENT-4564)

**Description**

Currently, if enrollment via data sharing consent (DSC) fails for any reason, an alert banner with the same copy is used, regardless of the reason for the failure.

This PR takes in an additional query parameter `failure_reason` to determine which alert messaging to use depending on why the enrollment failed. This is primarily to help distinguish the following failure reason messaging:
1. Denying DSC
1. Accepting DSC but verification deadline has passed

Note, the alert messaging for the verification deadline failure case was run by UX and deemed "good enough" while they check on any similar messaging on the B2C side of things. We may need to come back and update the copy for this alert if/when the similar messaging is found.

**Screenshot**
![image](https://user-images.githubusercontent.com/2828721/130286983-dd645a4a-4901-48ad-bddf-2dd626120edc.png)

**Testing instructions**
1. Load the course about page without any query parameters. Confirm no alert appears.
2. Load the course about page with the following query parameters: `?enrollment_failed=true&failure_reason=dsc_denied`. Confirm the "must accept DSC terms" alert messaging appears.
3. Load the course about page with the following query parameters: `?enrollment_failed=true&failure_reason=verification_deadline`. Confirm the "verification deadline has passed" alert messaging appears.