### PR TITLE
Fix: Update Enrollment Codes count to use redemptions_remaining instead of count from backend.

### DIFF
--- a/src/components/enterprise-user-subsidy/offers/data/actions.js
+++ b/src/components/enterprise-user-subsidy/offers/data/actions.js
@@ -5,6 +5,8 @@ import {
   FETCH_OFFERS_SUCCESS,
   FETCH_OFFERS_FAILURE,
 } from './constants';
+
+import findOfferRedemptionCount from './utils';
 import * as service from './service';
 
 const fetchOffersRequest = () => ({
@@ -15,7 +17,7 @@ const fetchOffersSuccess = data => ({
   type: FETCH_OFFERS_SUCCESS,
   payload: {
     offers: data.results,
-    offersCount: data.count,
+    offersCount: findOfferRedemptionCount(data.results),
   },
 });
 

--- a/src/components/enterprise-user-subsidy/offers/data/tests/actions.test.js
+++ b/src/components/enterprise-user-subsidy/offers/data/tests/actions.test.js
@@ -17,14 +17,14 @@ describe('fetchOffers action', () => {
       {
         type: FETCH_OFFERS_SUCCESS,
         payload: {
-          offers: [{ fooBar: 'foo' }],
+          offers: [{ fooBar: 'foo', redemptionsRemaining: 2 }],
           offersCount: 2,
         },
       },
     ];
 
     service.fetchOffers.mockImplementation((
-      () => Promise.resolve({ data: { results: [{ foo_bar: 'foo' }], count: 2 } })
+      () => Promise.resolve({ data: { results: [{ foo_bar: 'foo', redemptions_remaining: 2 }], count: 2 } })
     ));
     const dispatchSpy = jest.fn();
     return fetchOffers(null, dispatchSpy)

--- a/src/components/enterprise-user-subsidy/offers/data/tests/utils.test.js
+++ b/src/components/enterprise-user-subsidy/offers/data/tests/utils.test.js
@@ -1,0 +1,17 @@
+import findOfferRedemptionCount from '../utils';
+
+describe('find offer redemption count function', () => {
+  it('should not fail and return 0 if there are no remaining redemptions', () => {
+    const offers = [{ code: 'ARGLBLARGL', redemptionsRemaining: 0 }];
+    expect(findOfferRedemptionCount(offers)).toEqual(0);
+  });
+
+  it('should return total sum of redemptions remaining when provided multiple codes', () => {
+    const offers = [
+      { code: '3254XDF', redemptionsRemaining: 5 },
+      { code: '89KJDRHNF', redemptionsRemaining: 7 },
+      { code: 'LKJ3LJ38', redemptionsRemaining: 3 },
+    ];
+    expect(findOfferRedemptionCount(offers)).toEqual(15);
+  });
+});

--- a/src/components/enterprise-user-subsidy/offers/data/utils.jsx
+++ b/src/components/enterprise-user-subsidy/offers/data/utils.jsx
@@ -1,0 +1,8 @@
+export default function findOfferRedemptionCount(offers) {
+  let totalRedemptionsRemaining = 0;
+  offers.forEach((offer) => {
+    totalRedemptionsRemaining += offer.redemptionsRemaining;
+  });
+
+  return totalRedemptionsRemaining;
+}


### PR DESCRIPTION
### Background
In order to make the UI less confusing for users we wanted to incorporate multi-use codes into the count returned in the learner portal.

Previously, we were using the count which is the total number of offers (aka unique codes). This means a multi-use code which may have many redemptions associated only shows as a count of 1.

### Changes

This PR swaps `offerCount` from this count variable (which comes from what exactly I don't know. Seems like a default/standard part of the response that just counts objects (it's on the same level as nextPage, etc.)) to a calculation based on the actual `redemptions_remaining` attribute that is on each coupon.

I updated an existing test that utilized counts and also added a test for the new utility calculation redemptions remaining.

### Screenshots:
- These show the result of 2 codes, one single use code and 1 multi use with 15 redemptions assigned.
- I also added a screenshot showing the object so you can also see what I mean above about the weirdness of the count variable.
![Screen Shot 2021-08-23 at 3 54 50 PM](https://user-images.githubusercontent.com/66267747/130512914-e08514e0-c2cd-4d9f-b53e-20e85a97dc6d.png)
![Screen Shot 2021-08-23 at 3 52 21 PM](https://user-images.githubusercontent.com/66267747/130512915-5233d257-9190-47ce-a105-4da67d6a2c4a.png)
![Screen Shot 2021-08-23 at 3 52 08 PM](https://user-images.githubusercontent.com/66267747/130512916-13366bec-6c1a-43d6-9b19-d0b64e1fb688.png)
![Screen Shot 2021-08-23 at 3 50 39 PM](https://user-images.githubusercontent.com/66267747/130512918-8749161b-444d-4fff-af07-25b886775aa0.png)
