### PR TITLE
build: upgrade to frontend-build v8.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1400,9 +1400,9 @@
       "dev": true
     },
     "@edx/frontend-build": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-build/-/frontend-build-8.0.3.tgz",
-      "integrity": "sha512-50S6IbLjllxk9JFx3VGO2R6WKHcW1GRjv1TUYFOuk2u7emokDFRE9HK2adsT/PSViwvwQI/fjP6QKjyH5aucxw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-build/-/frontend-build-8.0.4.tgz",
+      "integrity": "sha512-j1GXQEONHyWgCBRDKuZIIQYh0Uda4sTmDI9kShPgEa93wwLryvUexsoJhrr7gHz+cHF2EdyyR8/3fnZYhZLjdw==",
       "dev": true,
       "requires": {
         "@babel/cli": "7.10.5",
@@ -5868,9 +5868,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -6896,9 +6896,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.812",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.812.tgz",
-      "integrity": "sha512-7KiUHsKAWtSrjVoTSzxQ0nPLr/a+qoxNZwkwd9LkylTOgOXSVXkQbpIVT0WAUQcI5gXq3SwOTCrK+WfINHOXQg==",
+      "version": "1.3.816",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.816.tgz",
+      "integrity": "sha512-/AvJPIJldO0NkwkfpUD7u1e4YEGRFBQpFuvl9oGCcVgWOObsZB1loxVGeVUJB9kmvfsBUUChPYdgRzx6+AKNyg==",
       "dev": true
     },
     "email-prop-type": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "universal-cookie": "4.0.4"
   },
   "devDependencies": {
-    "@edx/frontend-build": "8.0.3",
+    "@edx/frontend-build": "^8.0.4",
     "@testing-library/jest-dom": "5.11.9",
     "@testing-library/react": "11.2.5",
     "@testing-library/react-hooks": "3.7.0",


### PR DESCRIPTION
Upgrades to `@edx/frontend-build` v8.0.4 to resolve the following error when starting the Webpack Dev Server:

> [webpack-cli] Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.