### PR TITLE
fix: remove ignored errors regex

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,9 +34,6 @@ initialize({
         ALGOLIA_INDEX_NAME: process.env.ALGOLIA_INDEX_NAME || null,
         INTEGRATION_WARNING_DISMISSED_COOKIE_NAME: process.env.INTEGRATION_WARNING_DISMISSED_COOKIE_NAME || null,
         SHOW_MAINTENANCE_ALERT: process.env.SHOW_MAINTENANCE_ALERT,
-        // Logs JS errors matching the following regex as NewRelic page actions instead of
-        // errors,reducing JS error noise.
-        IGNORED_ERROR_REGEX: '(Axios Error|\'removeChild\'|Script error|getReadModeExtract)',
         ENABLE_SKILLS_QUIZ: process.env.ENABLE_SKILLS_QUIZ || false,
       });
     },


### PR DESCRIPTION
We had previously ignored specific errors to reduce JS error noise in the Enterprise Learner Portal. The previously-ignored errors were causing lots of erroneous error spikes due to lower traffic at the time. But with a higher traffic volume now, these errors likely will be useful again 🤞 

Since we're investigating a JS error related to an Axios error, let's remove the `IGNORED_ERROR_REGEX` such that we should get more visibility into how often these 401 errors on course about pages are occurring.