### PR TITLE
fix: add 30 day expiration modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ This is nice if you want to use VScode built in debugger and also make changes a
 
 In VSCode, click on the Debug button to the left toolbar
 
-Go to add configuratoin and select type 'chrome'
+Go to add configuration and select type 'chrome'
 
 VScode will generate a file in .vscode/launch.json that looks like this, edit it as shown to your desired url
 

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -8,6 +8,7 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 
 import {
+  SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL,
   SUBSCRIPTION_DAYS_REMAINING_SEVERE,
   SUBSCRIPTION_EXPIRED,
   SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX,
@@ -19,11 +20,11 @@ export const SUBSCRIPTION_EXPIRING_MODAL_TITLE = 'Your subscription is expiring'
 
 const SubscriptionExpirationModal = () => {
   const {
-    enterpriseConfig: { contactEmail },
+    enterpriseConfig: { uuid: enterpriseId, contactEmail },
     config,
   } = useContext(AppContext);
   const { subscriptionPlan } = useContext(UserSubsidyContext);
-  const { daysUntilExpiration, expirationDate } = subscriptionPlan;
+  const { daysUntilExpiration, expirationDate, uuid: subscriptionPlanId } = subscriptionPlan;
 
   const renderTitle = () => {
     if (daysUntilExpiration > SUBSCRIPTION_EXPIRED) {
@@ -116,7 +117,16 @@ const SubscriptionExpirationModal = () => {
     return null;
   }
 
-  const seenCurrentExpirationModalCookieName = `${SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX}${SUBSCRIPTION_DAYS_REMAINING_SEVERE}`;
+  const subscriptionExpirationThresholds = [
+    SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL,
+    SUBSCRIPTION_DAYS_REMAINING_SEVERE,
+  ];
+
+  const subscriptionExpirationThreshold = subscriptionExpirationThresholds.find(
+    threshold => threshold >= daysUntilExpiration,
+  );
+
+  const seenCurrentExpirationModalCookieName = `${SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX}${subscriptionExpirationThreshold}-${enterpriseId}-${subscriptionPlanId}`;
   const cookies = new Cookies();
   const seenCurrentExpirationModal = cookies.get(seenCurrentExpirationModalCookieName);
   // If they have already seen the expiration modal for their current expiration range (as

--- a/src/components/dashboard/tests/Dashboard.test.jsx
+++ b/src/components/dashboard/tests/Dashboard.test.jsx
@@ -2,31 +2,99 @@ import React from 'react';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { breakpoints } from '@edx/paragon';
+import Cookies from 'universal-cookie';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { CourseContextProvider } from '../../course/CourseContextProvider';
-import { COURSE_PACING_MAP } from '../../course/data/constants';
-import { TEST_OWNER } from '../../course/tests/data/constants';
+import {
+  SUBSCRIPTION_EXPIRED_MODAL_TITLE,
+  SUBSCRIPTION_EXPIRING_MODAL_TITLE,
+} from '../SubscriptionExpirationModal';
+import {
+  SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX,
+} from '../../../config/constants';
+import * as service from '../main-content/course-enrollments/data/service';
 
 import {
   renderWithRouter, fakeReduxStore,
 } from '../../../utils/tests';
 import Dashboard, { LICENCE_ACTIVATION_MESSAGE } from '../Dashboard';
-import {
-  SUBSCRIPTION_EXPIRED_MODAL_TITLE,
-  SUBSCRIPTION_EXPIRING_MODAL_TITLE,
-} from '../SubscriptionExpirationModal';
+import { TEST_OWNER } from '../../course/tests/data/constants';
+import { COURSE_PACING_MAP } from '../../course/data/constants';
+
+const defaultOffersState = {
+  offers: [],
+  loading: false,
+  offersCount: 0,
+};
+
+const defaultAppState = {
+  enterpriseConfig: {
+    name: 'BearsRUs',
+    uuid: 'BearsRUs',
+  },
+  config: {
+    LMS_BASE_URL: process.env.LMS_BASE_URL,
+  },
+};
+
+const defaultUserSubsidyState = {
+  hasAccessToPortal: true,
+  offers: defaultOffersState,
+};
+
+const defaultCourseState = {
+  course: {
+    subjects: [{
+      name: 'Test Subject 1',
+      slug: 'test-subject-slug',
+    }],
+    shortDescription: 'Course short description.',
+    title: 'Test Course Title',
+    owners: [TEST_OWNER],
+    programs: [],
+    image: {
+      src: 'http://test-image.url',
+    },
+  },
+  activeCourseRun: {
+    isEnrollable: true,
+    key: 'test-course-run-key',
+    pacingType: COURSE_PACING_MAP.SELF_PACED,
+    start: '2020-09-09T04:00:00Z',
+    availability: 'Current',
+    courseUuid: 'Foo',
+  },
+  userEnrollments: [],
+  userEntitlements: [],
+  catalog: {
+    containsContentItems: true,
+  },
+};
+
+const mockWindowConfig = {
+  type: 'screen',
+  width: breakpoints.large.minWidth + 1,
+  height: 800,
+};
+
+let mockLocation = {
+  pathname: '/welcome',
+  hash: '',
+  search: '',
+  state: { activationSuccess: true },
+};
 
 const mockStore = configureMockStore([thunk]);
 
 /* eslint-disable react/prop-types */
 const DashboardWithContext = ({
-  initialAppState = {},
-  initialUserSubsidyState = {},
-  initialCourseState = {},
+  initialAppState = defaultAppState,
+  initialUserSubsidyState = defaultUserSubsidyState,
+  initialCourseState = defaultCourseState,
   initialReduxStore = fakeReduxStore,
 }) => (
   <AppContext.Provider value={initialAppState}>
@@ -41,13 +109,6 @@ const DashboardWithContext = ({
 );
 /* eslint-enable react/prop-types */
 
-let mockLocation = {
-  pathname: '/welcome',
-  hash: '',
-  search: '',
-  state: { activationSuccess: true },
-};
-
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => (mockLocation),
@@ -58,69 +119,21 @@ jest.mock('@edx/frontend-platform/auth', () => ({
   getAuthenticatedUser: () => ({ username: 'myspace-tom' }),
 }));
 
-describe('<Dashboard />', () => {
-  const defaultOffersState = {
-    offers: [],
-    loading: false,
-    offersCount: 0,
-  };
-  const initialAppState = {
-    enterpriseConfig: {
-      name: 'BearsRUs',
-    },
-    config: {
-      LMS_BASE_URL: process.env.LMS_BASE_URL,
-    },
-  };
-  const initialUserSubsidyState = {
-    hasAccessToPortal: true,
-    offers: defaultOffersState,
-  };
-  const mockWindowConfig = {
-    type: 'screen',
-    width: breakpoints.large.minWidth + 1,
-    height: 800,
-  };
-  const initialCourseState = {
-    course: {
-      subjects: [{
-        name: 'Test Subject 1',
-        slug: 'test-subject-slug',
-      }],
-      shortDescription: 'Course short description.',
-      title: 'Test Course Title',
-      owners: [TEST_OWNER],
-      programs: [],
-      image: {
-        src: 'http://test-image.url',
-      },
-    },
-    activeCourseRun: {
-      isEnrollable: true,
-      key: 'test-course-run-key',
-      pacingType: COURSE_PACING_MAP.SELF_PACED,
-      start: '2020-09-09T04:00:00Z',
-      availability: 'Current',
-      courseUuid: 'Foo',
-    },
-    userEnrollments: [],
-    userEntitlements: [],
-    catalog: {
-      containsContentItems: true,
-    },
-  };
-  const mockSubscriptionPlan = {
-    expirationDate: '2020-10-25',
-    daysUntilExpiration: 365,
-  };
+jest.mock('universal-cookie');
+jest.mock('../main-content/course-enrollments/data/service');
 
+service.fetchEnterpriseCourseEnrollments.mockResolvedValue(undefined);
+// eslint-disable-next-line no-console
+console.error = jest.fn();
+
+describe('<Dashboard />', () => {
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
   it('renders license activation alert on activation success', () => {
     renderWithRouter(
-      <DashboardWithContext initialAppState={initialAppState} initialUserSubsidyState={initialUserSubsidyState} />,
+      <DashboardWithContext />,
       { route: '/?activationSuccess=true' },
     );
     expect(screen.getByText(LICENCE_ACTIVATION_MESSAGE)).toBeTruthy();
@@ -130,107 +143,15 @@ describe('<Dashboard />', () => {
     // NOTE: This modifies the original mockLocation
     mockLocation = { ...mockLocation, state: { activationSuccess: false } };
     renderWithRouter(
-      <DashboardWithContext initialAppState={initialAppState} initialUserSubsidyState={initialUserSubsidyState} />,
+      <DashboardWithContext />,
     );
     expect(screen.queryByText(LICENCE_ACTIVATION_MESSAGE)).toBeFalsy();
-  });
-
-  it('does not render subscription expiration modal when >60 days of access remain', () => {
-    renderWithRouter(
-      <DashboardWithContext
-        initialAppState={initialAppState}
-        initialUserSubsidyState={initialUserSubsidyState}
-        initialCourseState={initialCourseState}
-      />,
-    );
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
-  });
-
-  it('renders the subscription expiration warning modal when 60 >= daysUntilExpiration > 0', () => {
-    const expiringSubscriptionUserSubsidyState = {
-      ...initialUserSubsidyState,
-      subscriptionPlan: {
-        ...mockSubscriptionPlan,
-        daysUntilExpiration: 60,
-      },
-      showExpirationNotifications: true,
-    };
-    renderWithRouter(
-      <DashboardWithContext
-        initialAppState={initialAppState}
-        initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
-        initialCourseState={initialCourseState}
-      />,
-    );
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeTruthy();
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
-  });
-
-  it('does not render the modals when 60 >= daysUntilExpiration > 0 and expiration messages are disabled', () => {
-    const expiringSubscriptionUserSubsidyState = {
-      ...initialUserSubsidyState,
-      subscriptionPlan: {
-        ...mockSubscriptionPlan,
-        daysUntilExpiration: 60,
-      },
-      showExpirationNotifications: false,
-    };
-    renderWithRouter(
-      <DashboardWithContext
-        initialAppState={initialAppState}
-        initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
-        initialCourseState={initialCourseState}
-      />,
-    );
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
-  });
-
-  it('renders the subscription expired modal when 0 >= daysUntilExpiration', () => {
-    const expiringSubscriptionUserSubsidyState = {
-      ...initialUserSubsidyState,
-      subscriptionPlan: {
-        ...mockSubscriptionPlan,
-        daysUntilExpiration: 0,
-      },
-      showExpirationNotifications: true,
-    };
-    renderWithRouter(
-      <DashboardWithContext
-        initialAppState={initialAppState}
-        initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
-        initialCourseState={initialCourseState}
-      />,
-    );
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeTruthy();
-  });
-
-  it('does not render the modals when 0 >= daysUntilExpiration and expiration messages are disabled ', () => {
-    const expiringSubscriptionUserSubsidyState = {
-      ...initialUserSubsidyState,
-      subscriptionPlan: {
-        ...mockSubscriptionPlan,
-        daysUntilExpiration: 0,
-      },
-      showExpirationNotifications: false,
-    };
-    renderWithRouter(
-      <DashboardWithContext
-        initialAppState={initialAppState}
-        initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
-        initialCourseState={initialCourseState}
-      />,
-    );
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
-    expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
   });
 
   it('renders a sidebar on a large screen', () => {
     window.matchMedia.setConfig(mockWindowConfig);
     renderWithRouter(
-      <DashboardWithContext initialAppState={initialAppState} initialUserSubsidyState={initialUserSubsidyState} />,
+      <DashboardWithContext />,
     );
     expect(screen.getByTestId('sidebar')).toBeTruthy();
   });
@@ -238,11 +159,194 @@ describe('<Dashboard />', () => {
   it('renders a sidebar on a small screen', () => {
     window.matchMedia.setConfig({ ...mockWindowConfig, width: breakpoints.large.minWidth - 1 });
     renderWithRouter(
-      <DashboardWithContext
-        initialAppState={initialAppState}
-        initialUserSubsidyState={initialUserSubsidyState}
-      />,
+      <DashboardWithContext />,
     );
     expect(screen.getByTestId('sidebar')).toBeTruthy();
+  });
+
+  describe('SubscriptionExpirationModal', () => {
+    it('should not render when > 60 days of access remain', () => {
+      renderWithRouter(
+        <DashboardWithContext />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+    });
+
+    it('should render when 60 >= daysUntilExpiration > 0', () => {
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultUserSubsidyState,
+        subscriptionPlan: {
+          daysUntilExpiration: 60,
+        },
+        showExpirationNotifications: true,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeTruthy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+    });
+
+    it('should render the expired version of the modal when 0 >= daysUntilExpiration', () => {
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultUserSubsidyState,
+        subscriptionPlan: {
+          daysUntilExpiration: 0,
+        },
+        showExpirationNotifications: true,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeTruthy();
+    });
+
+    it('should not render when 0 >= daysUntilExpiration and expiration messages are disabled ', () => {
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultUserSubsidyState,
+        subscriptionPlan: {
+          daysUntilExpiration: 0,
+        },
+        showExpirationNotifications: false,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+    });
+
+    it('should not render when 60 >= daysUntilExpiration > 0 and expiration messages are disabled', () => {
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultUserSubsidyState,
+        subscriptionPlan: {
+          daysUntilExpiration: 60,
+        },
+        showExpirationNotifications: false,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+    });
+
+    it('should render the expiration warning version of the modal when 60 >= daysUntilExpiration > 0', () => {
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultUserSubsidyState,
+        subscriptionPlan: {
+          daysUntilExpiration: 60,
+        },
+        showExpirationNotifications: true,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeTruthy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+    });
+
+    it('should set the 60 day cookie when closed for the 60 day threshold', () => {
+      const mockSetCookies = jest.fn();
+      Cookies.mockReturnValue({ get: () => null, set: mockSetCookies });
+
+      const subscriptionPlanId = 'expiring-plan-60';
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultOffersState,
+        subscriptionPlan: {
+          uuid: subscriptionPlanId,
+          daysUntilExpiration: 60,
+        },
+        showExpirationNotifications: true,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeTruthy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+      const modal = screen.getByRole('dialog');
+      fireEvent.click(modal.querySelector('button'));
+      expect(mockSetCookies).toHaveBeenCalledWith(
+        `${SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX}60-${defaultAppState.enterpriseConfig.uuid}-${subscriptionPlanId}`, true, { sameSite: 'strict' },
+      );
+    });
+
+    it('should not show the modal if 60 >= daysUntilExpiration > 30 and the 60 day cookie has been set', () => {
+      Cookies.mockReturnValue({ get: () => 'cookie' });
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultOffersState,
+        subscriptionPlan: {
+          daysUntilExpiration: 60,
+        },
+        showExpirationNotifications: true,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+    });
+
+    it('should set the 30 day cookie when closed for the 30 day threshold', () => {
+      const mockSetCookies = jest.fn();
+      Cookies.mockReturnValue({ get: () => null, set: mockSetCookies });
+
+      const subscriptionPlanId = 'expiring-plan-30';
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultOffersState,
+        subscriptionPlan: {
+          uuid: subscriptionPlanId,
+          daysUntilExpiration: 30,
+        },
+        showExpirationNotifications: true,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeTruthy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+      const modal = screen.getByRole('dialog');
+      fireEvent.click(modal.querySelector('button'));
+      expect(mockSetCookies).toHaveBeenCalledWith(
+        `${SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX}30-${defaultAppState.enterpriseConfig.uuid}-${subscriptionPlanId}`, true, { sameSite: 'strict' },
+      );
+    });
+
+    it('should not show the modal if 30 >= daysUntilExpiration > 0 and the 30 day cookie has been set', () => {
+      Cookies.mockReturnValue({ get: () => 'cookie' });
+      const expiringSubscriptionUserSubsidyState = {
+        ...defaultOffersState,
+        subscriptionPlan: {
+          daysUntilExpiration: 30,
+        },
+        showExpirationNotifications: true,
+      };
+      renderWithRouter(
+        <DashboardWithContext
+          initialUserSubsidyState={expiringSubscriptionUserSubsidyState}
+        />,
+      );
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRING_MODAL_TITLE)).toBeFalsy();
+      expect(screen.queryByText(SUBSCRIPTION_EXPIRED_MODAL_TITLE)).toBeFalsy();
+    });
   });
 });

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,8 +1,8 @@
 export const FEATURE_ENROLL_WITH_CODES = 'ENROLL_WITH_CODES';
 
 // Subscription expiration constants
-// LP only needs warnings within 60 days of expiration and past expiration
 export const SUBSCRIPTION_DAYS_REMAINING_SEVERE = 60;
+export const SUBSCRIPTION_DAYS_REMAINING_EXCEPTIONAL = 30;
 export const SUBSCRIPTION_EXPIRED = 0;
 
 // Prefix for cookies that determine if the user has seen the modal for that range of expiration


### PR DESCRIPTION
[ENT-4628](https://openedx.atlassian.net/browse/ENT-4628)

The 30 day expiration modal was not being shown in the learner portal previously. This change adds it.

**Testing instructions**
1. Open the learner portal with a subscription expiring in <= 60 days.
2. Check that an expiration modal is shown
3. Close the modal and verify that a cookie has been set
4. Refresh the page and verify that the modal does not show up again
5. Update the subscription expiry date to be <= 30 days
6. Repeat steps 2-4

