### PR TITLE
feat: add alert to inform learner to activate license

### DIFF
--- a/src/components/app/AuthenticatedUserSubsidyPage.jsx
+++ b/src/components/app/AuthenticatedUserSubsidyPage.jsx
@@ -2,12 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import AuthenticatedPage from './AuthenticatedPage';
-import { UserSubsidy } from '../enterprise-user-subsidy';
+import {
+  ActivateLicenseAlert,
+  UserSubsidy,
+} from '../enterprise-user-subsidy';
 
 export default function AuthenticatedUserSubsidyPage({ children }) {
   return (
     <AuthenticatedPage>
       <UserSubsidy>
+        <ActivateLicenseAlert />
         {children}
       </UserSubsidy>
     </AuthenticatedPage>

--- a/src/components/app/AuthenticatedUserSubsidyPage.test.jsx
+++ b/src/components/app/AuthenticatedUserSubsidyPage.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import AuthenticatedUserSubsidyPage from './AuthenticatedUserSubsidyPage';
 import AuthenticatedPage from './AuthenticatedPage';
-import { UserSubsidy } from '../enterprise-user-subsidy';
+import { ActivateLicenseAlert, UserSubsidy } from '../enterprise-user-subsidy';
 
 describe('<AuthenticatedUserSubsidyPage />', () => {
   let wrapper;
@@ -20,6 +20,9 @@ describe('<AuthenticatedUserSubsidyPage />', () => {
   });
   it('renders <UserSubsidy>', () => {
     expect(wrapper.find(UserSubsidy)).toBeTruthy();
+  });
+  it('renders <ActivateLicenseAlert>', () => {
+    expect(wrapper.find(ActivateLicenseAlert)).toBeTruthy();
   });
   it('renders children', () => {
     expect(wrapper.find('div.did-i-render')).toBeTruthy();

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import MediaQuery from 'react-responsive';
 import {
   Container, Alert, Row, breakpoints, useToggle,
@@ -14,13 +14,22 @@ import { DashboardSidebar } from './sidebar';
 import SubscriptionExpirationModal from './SubscriptionExpirationModal';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 
-export const LICENCE_ACTIVATION_MESSAGE = 'Your license has been successfully activated.';
+export const LICENCE_ACTIVATION_MESSAGE = 'Your license was successfully activated.';
 
 export default function Dashboard() {
   const { enterpriseConfig } = useContext(AppContext);
   const { subscriptionPlan, showExpirationNotifications } = useContext(UserSubsidyContext);
   const { state } = useLocation();
+  const history = useHistory();
   const [isActivationAlertOpen, , closeActivationAlert] = useToggle(!!state?.activationSuccess);
+
+  useEffect(() => {
+    if (state?.activationSuccess) {
+      const updatedLocationState = { ...state };
+      delete updatedLocationState.activationSuccess;
+      history.replace({ ...history.location, state: updatedLocationState });
+    }
+  }, []);
 
   const renderLicenseActivationSuccess = () => (
     <Alert variant="success" show={isActivationAlertOpen} onClose={closeActivationAlert} dismissible>
@@ -32,8 +41,10 @@ export default function Dashboard() {
   return (
     <>
       <Helmet title={PAGE_TITLE} />
-      <Container size="lg" className="py-5">
+      <Container size="lg" className="mt-3">
         {renderLicenseActivationSuccess()}
+      </Container>
+      <Container size="lg" className="py-5">
         <Row>
           <MainContent>
             <DashboardMainContent />

--- a/src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx
+++ b/src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx
@@ -1,0 +1,45 @@
+import React, { useContext } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Alert, Button, Container } from '@edx/paragon';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+
+import { UserSubsidyContext } from './UserSubsidy';
+
+/**
+ * An alert to inform the learner they have an assigned license that is not yet
+ * activated. Provides a CTA button that links to the license activation route.
+ */
+const ActivateLicenseAlert = () => {
+  const { enterpriseSlug } = useParams();
+  const { subscriptionLicense } = useContext(UserSubsidyContext);
+  if (!subscriptionLicense || ['activated', 'revoked'].includes(subscriptionLicense.status)) {
+    return null;
+  }
+  const { activationKey } = subscriptionLicense;
+  return (
+    <Container size="lg" className="mt-3">
+      <Alert variant="warning">
+        <div className="d-flex align-items-center justify-content-between">
+          <span>
+            Your subscription license is not activated. To enroll in courses without
+            payment, you must activate your license.
+          </span>
+          <Button
+            as={Link}
+            variant="primary"
+            size="sm"
+            to={`/${enterpriseSlug}/licenses/${activationKey}/activate`}
+            onClick={() => {
+              sendTrackEvent('edx.ui.enterprise.learner_portal.activate_license_alert.activate_cta.clicked');
+            }}
+            data-testid="activateCta"
+          >
+            Activate your license
+          </Button>
+        </div>
+      </Alert>
+    </Container>
+  );
+};
+
+export default ActivateLicenseAlert;

--- a/src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx
+++ b/src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx
@@ -34,7 +34,7 @@ const ActivateLicenseAlert = () => {
             }}
             data-testid="activateCta"
           >
-            Activate your license
+            Activate now
           </Button>
         </div>
       </Alert>

--- a/src/components/enterprise-user-subsidy/index.js
+++ b/src/components/enterprise-user-subsidy/index.js
@@ -1,1 +1,2 @@
 export { default as UserSubsidy, UserSubsidyContext } from './UserSubsidy';
+export { default as ActivateLicenseAlert } from './ActivateLicenseAlert';

--- a/src/components/enterprise-user-subsidy/tests/ActivateLicenseAlert.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/ActivateLicenseAlert.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import '@testing-library/jest-dom/extend-expect';
+import { screen } from '@testing-library/react';
+
+import ActivateLicenseAlert from '../ActivateLicenseAlert';
+
+import { UserSubsidyContext } from '../UserSubsidy';
+import { renderWithRouter } from '../../../utils/tests';
+
+const TEST_ENTERPRISE_SLUG = 'test-slug';
+
+describe('<ActivateLicenseAlert />', () => {
+  test('does not render alert when no license exists', () => {
+    const Component = (
+      <Route path="/:enterpriseSlug">
+        <UserSubsidyContext.Provider value={{ subscriptionLicense: null }}>
+          <ActivateLicenseAlert />
+        </UserSubsidyContext.Provider>
+      </Route>
+    );
+    renderWithRouter(Component, {
+      route: `/${TEST_ENTERPRISE_SLUG}`,
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test.each(
+    ['activated', 'revoked'],
+  )('does not render alert when license status is %s', (status) => {
+    const subscriptionLicense = { status };
+    const Component = (
+      <Route path="/:enterpriseSlug">
+        <UserSubsidyContext.Provider value={{ subscriptionLicense }}>
+          <ActivateLicenseAlert />
+        </UserSubsidyContext.Provider>
+      </Route>
+    );
+    renderWithRouter(Component, {
+      route: `/${TEST_ENTERPRISE_SLUG}`,
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('renders alert when license status is assigned', () => {
+    const TEST_ACTIVATION_KEY = 'activation-key-uuid';
+    const subscriptionLicense = {
+      status: 'assigned',
+      activationKey: TEST_ACTIVATION_KEY,
+    };
+    const Component = (
+      <Route path="/:enterpriseSlug">
+        <UserSubsidyContext.Provider value={{ subscriptionLicense }}>
+          <ActivateLicenseAlert />
+        </UserSubsidyContext.Provider>
+      </Route>
+    );
+    renderWithRouter(Component, {
+      route: `/${TEST_ENTERPRISE_SLUG}`,
+    });
+    expect(screen.getByRole('alert')).toBeTruthy();
+    const activateCtaPath = screen.getByTestId('activateCta').getAttribute('href');
+    const expectedActivateCtaPath = `/${TEST_ENTERPRISE_SLUG}/licenses/${TEST_ACTIVATION_KEY}/activate`;
+    expect(activateCtaPath).toEqual(expectedActivateCtaPath);
+  });
+});


### PR DESCRIPTION
Back in June, we unintentionally removed an alert that informed the learner they had an assigned license that needed to be activated. This PR adds it back in, with some improvements. Before, it told the learner to go click the link in their activation email. This banner, however, includes a CTA button with the link itself (i.e., no need to refer to their email).

The alert will show on the Dashboard, Search, or Course pages to handle all the possible entry points to the app for the learner (e.g., SSO users land on course page directly).

Also fixes a bug where the license activation alert would persist even after a full page refresh.

**Screenshots:**
![image](https://user-images.githubusercontent.com/2828721/132062413-3f5f4e55-0137-4f43-a09a-422ebaeb729e.png)

**Note: Copy is being reviewed by UX.**