### PR TITLE
fix: add login refresh component 

### DIFF
--- a/src/components/app/AuthenticatedPage.jsx
+++ b/src/components/app/AuthenticatedPage.jsx
@@ -8,6 +8,7 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { EnterprisePage } from '../enterprise-page';
 import { EnterpriseBanner } from '../enterprise-banner';
 import { Layout } from '../layout';
+import LoginRefresh from './LoginRefresh';
 
 export default function AuthenticatedPage({ children, useEnterpriseConfigCache }) {
   const config = getConfig();
@@ -23,12 +24,14 @@ export default function AuthenticatedPage({ children, useEnterpriseConfigCache }
 
   return (
     <LoginRedirect>
-      <EnterprisePage useEnterpriseConfigCache={useEnterpriseConfigCache}>
-        <Layout>
-          <EnterpriseBanner />
-          {children}
-        </Layout>
-      </EnterprisePage>
+      <LoginRefresh>
+        <EnterprisePage useEnterpriseConfigCache={useEnterpriseConfigCache}>
+          <Layout>
+            <EnterpriseBanner />
+            {children}
+          </Layout>
+        </EnterprisePage>
+      </LoginRefresh>
     </LoginRedirect>
   );
 }

--- a/src/components/app/LoginRefresh.jsx
+++ b/src/components/app/LoginRefresh.jsx
@@ -1,0 +1,35 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { Container } from '@edx/paragon';
+
+import { LoadingSpinner } from '../loading-spinner';
+import { loginRefresh } from '../../utils/common';
+
+export default function LoginRefresh({ children }) {
+  const { authenticatedUser } = useContext(AppContext);
+  const { roles } = authenticatedUser;
+
+  // If the user has not refreshed their JWT since they created their account,
+  // we should refresh it so that they'll have appropriate roles (if available),
+  // and thus, have any appropriate permissions when making downstream requests.
+  const [isRefreshingJWT, setIsRefreshingJWT] = useState(roles.length === 0);
+
+  useEffect(() => {
+    const refreshJWT = async () => {
+      await loginRefresh();
+      setIsRefreshingJWT(false);
+    };
+    if (isRefreshingJWT) {
+      refreshJWT();
+    }
+  }, [isRefreshingJWT]);
+
+  if (isRefreshingJWT) {
+    return (
+      <Container size="lg" className="py-5">
+        <LoadingSpinner screenReaderText="loading user details" />
+      </Container>
+    );
+  }
+  return children;
+}

--- a/src/components/app/LoginRefresh.test.jsx
+++ b/src/components/app/LoginRefresh.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, act } from '@testing-library/react';
+import { AppContext } from '@edx/frontend-platform/react';
+
+import LoginRefresh from './LoginRefresh';
+import * as utils from '../../utils/common';
+
+jest.mock('../../utils/common');
+
+// eslint-disable-next-line react/prop-types
+const LoginRefreshWithContext = ({ roles = [] }) => (
+  <AppContext.Provider value={{
+    authenticatedUser: {
+      userId: 1,
+      roles,
+    },
+  }}
+  >
+    <LoginRefresh>
+      <div>Hello!</div>
+    </LoginRefresh>
+  </AppContext.Provider>
+); /* eslint-enable react/prop-types */
+
+describe('<LoginRefresh />', () => {
+  it('should call loginRefresh if the user has no roles', async () => {
+    await act(async () => render(
+      <LoginRefreshWithContext />,
+    ));
+
+    expect(utils.loginRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call loginRefresh if the user has roles', async () => {
+    await act(async () => render(
+      <LoginRefreshWithContext roles={['role-1']} />,
+    ));
+  });
+
+  expect(utils.loginRefresh).not.toHaveBeenCalled();
+});

--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -1,39 +1,9 @@
-import React, { useContext, useEffect, useState } from 'react';
-import { AppContext } from '@edx/frontend-platform/react';
-import { Container } from '@edx/paragon';
+import React from 'react';
 
-import { LoadingSpinner } from '../loading-spinner';
 import Course from './Course';
 import AuthenticatedUserSubsidyPage from '../app/AuthenticatedUserSubsidyPage';
-import { loginRefresh } from '../../utils/common';
 
 export default function CoursePage() {
-  const { authenticatedUser } = useContext(AppContext);
-  const { roles } = authenticatedUser;
-
-  // If the user has not refreshed their JWT since they created their account,
-  // we should refresh it so that they'll have appropriate roles (if available),
-  // and thus, have any appropriate permissions when making downstream requests.
-  const [isRefreshingJWT, setIsRefreshingJWT] = useState(roles.length === 0);
-
-  useEffect(() => {
-    const refreshJWT = async () => {
-      await loginRefresh();
-      setIsRefreshingJWT(false);
-    };
-    if (isRefreshingJWT) {
-      refreshJWT();
-    }
-  }, [isRefreshingJWT]);
-
-  if (isRefreshingJWT) {
-    return (
-      <Container size="lg" className="py-5">
-        <LoadingSpinner screenReaderText="loading user details" />
-      </Container>
-    );
-  }
-
   return (
     <AuthenticatedUserSubsidyPage>
       <Course />


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-4885

Wrapping course page in authenticated page route. It seems like we have redirect login logic in both AuthenticatedPageRoute and AuthenticatedPage and there might opportunity for clean up.