### PR TITLE
fix: remove activation CTA from banner

### DIFF
--- a/src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx
+++ b/src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx
@@ -1,13 +1,11 @@
 import React, { useContext } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import { Alert, Button, Container } from '@edx/paragon';
-import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+import { Alert, Container } from '@edx/paragon';
 
 import { UserSubsidyContext } from './UserSubsidy';
 
 /**
- * An alert to inform the learner they have an assigned license that is not yet
- * activated. Provides a CTA button that links to the license activation route.
+ * An alert to inform the learner they have an assigned license
+ * that is not yet activated.
  */
 const ActivateLicenseAlert = () => {
   const { subscriptionLicense } = useContext(UserSubsidyContext);
@@ -18,8 +16,8 @@ const ActivateLicenseAlert = () => {
     <Container size="lg" className="mt-3">
       <Alert variant="warning">
         Your subscription license is not activated. To enroll in courses without
-        payment, you must activate your license from the activation link sent to
-        your email.
+        payment, you must activate your license by clicking the activation link
+        sent to your email.
       </Alert>
     </Container>
   );

--- a/src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx
+++ b/src/components/enterprise-user-subsidy/ActivateLicenseAlert.jsx
@@ -10,33 +10,16 @@ import { UserSubsidyContext } from './UserSubsidy';
  * activated. Provides a CTA button that links to the license activation route.
  */
 const ActivateLicenseAlert = () => {
-  const { enterpriseSlug } = useParams();
   const { subscriptionLicense } = useContext(UserSubsidyContext);
   if (!subscriptionLicense || ['activated', 'revoked'].includes(subscriptionLicense.status)) {
     return null;
   }
-  const { activationKey } = subscriptionLicense;
   return (
     <Container size="lg" className="mt-3">
       <Alert variant="warning">
-        <div className="d-flex align-items-center justify-content-between">
-          <span>
-            Your subscription license is not activated. To enroll in courses without
-            payment, you must activate your license.
-          </span>
-          <Button
-            as={Link}
-            variant="primary"
-            size="sm"
-            to={`/${enterpriseSlug}/licenses/${activationKey}/activate`}
-            onClick={() => {
-              sendTrackEvent('edx.ui.enterprise.learner_portal.activate_license_alert.activate_cta.clicked');
-            }}
-            data-testid="activateCta"
-          >
-            Activate now
-          </Button>
-        </div>
+        Your subscription license is not activated. To enroll in courses without
+        payment, you must activate your license from the activation link sent to
+        your email.
       </Alert>
     </Container>
   );

--- a/src/components/enterprise-user-subsidy/tests/ActivateLicenseAlert.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/ActivateLicenseAlert.test.jsx
@@ -43,11 +43,7 @@ describe('<ActivateLicenseAlert />', () => {
   });
 
   test('renders alert when license status is assigned', () => {
-    const TEST_ACTIVATION_KEY = 'activation-key-uuid';
-    const subscriptionLicense = {
-      status: 'assigned',
-      activationKey: TEST_ACTIVATION_KEY,
-    };
+    const subscriptionLicense = { status: 'assigned' };
     const Component = (
       <Route path="/:enterpriseSlug">
         <UserSubsidyContext.Provider value={{ subscriptionLicense }}>
@@ -59,8 +55,5 @@ describe('<ActivateLicenseAlert />', () => {
       route: `/${TEST_ENTERPRISE_SLUG}`,
     });
     expect(screen.getByRole('alert')).toBeTruthy();
-    const activateCtaPath = screen.getByTestId('activateCta').getAttribute('href');
-    const expectedActivateCtaPath = `/${TEST_ENTERPRISE_SLUG}/licenses/${TEST_ACTIVATION_KEY}/activate`;
-    expect(activateCtaPath).toEqual(expectedActivateCtaPath);
   });
 });


### PR DESCRIPTION
The alert that informs the learner they must activate their license currently includes an "Activate now" CTA that depends on the `activation_key` associated with the assigned license. However, it turns out `activation_key` is only available in the license serializer in `license-manager` in development and stage environment, but not production.

This caused learners who clicked the "Activate now" CTA on production to have an error during license activation since we were passing `undefined` to the license activation API endpoint.

As a quick fix, this PR updates the copy and removes the "Activate now" CTA to avoid these errors, and encourage the learner to click the activation link sent to their email.