### PR TITLE
fix: render enrollment failed alert even with no failure reason

### DIFF
--- a/src/components/course/CourseEnrollmentFailedAlert.jsx
+++ b/src/components/course/CourseEnrollmentFailedAlert.jsx
@@ -45,9 +45,8 @@ const CourseEnrollmentFailedAlert = () => {
     ),
     default: (
       <>
-        You were not enrolled in your selected course due to an unknown
-        error. Please {renderContactHelpText(Alert.Link)} for further
-        information.
+        You were not enrolled in your selected course. Please
+        {' '}{renderContactHelpText(Alert.Link)} for further information.
       </>
     ),
   };

--- a/src/components/course/CourseEnrollmentFailedAlert.jsx
+++ b/src/components/course/CourseEnrollmentFailedAlert.jsx
@@ -43,16 +43,23 @@ const CourseEnrollmentFailedAlert = () => {
         unavailable. Please {renderContactHelpText(Alert.Link)} for further information.
       </>
     ),
+    default: (
+      <>
+        You were not enrolled in your selected course due to an unknown
+        error. Please {renderContactHelpText(Alert.Link)} for further
+        information.
+      </>
+    ),
   };
 
-  if (!hasEnrollmentFailed || !failureReasonMessages[failureReason]) {
+  if (!hasEnrollmentFailed) {
     return null;
   }
 
   return (
     <Container size="lg" className="pt-3">
       <Alert variant="danger">
-        {failureReasonMessages[failureReason]}
+        {failureReasonMessages[failureReason] || failureReasonMessages.default}
       </Alert>
     </Container>
   );

--- a/src/components/course/tests/CourseHeader.test.jsx
+++ b/src/components/course/tests/CourseHeader.test.jsx
@@ -212,7 +212,7 @@ describe('<CourseHeader />', () => {
     enrollmentFailed  | failureReason                   | expectedMessage
     ${'true'}         | ${'dsc_denied'}                 | ${'accept the data sharing consent'}
     ${'true'}         | ${'verified_mode_unavailable'}  | ${'verified course mode is unavailable'}
-    ${'true'}         | ${''}                           | ${'unknown error'}
+    ${'true'}         | ${''}                           | ${'not enrolled'}
   `(
     'renders $failureReason alert with `enrollment_failed=$enrollmentFailed` and `failure_reason=$failureReason`',
     ({ enrollmentFailed, failureReason, expectedMessage }) => {

--- a/src/components/course/tests/CourseHeader.test.jsx
+++ b/src/components/course/tests/CourseHeader.test.jsx
@@ -189,7 +189,6 @@ describe('<CourseHeader />', () => {
   test.each`
     enrollmentFailed  | failureReason
     ${''}             | ${''}
-    ${'true'}         | ${''}
     ${''}             | ${'dsc_denied'}
   `(
     'does not render alert when `enrollment_failed=$enrollmentFailed` or `failure_reason=$failureReason`',
@@ -213,11 +212,16 @@ describe('<CourseHeader />', () => {
     enrollmentFailed  | failureReason                   | expectedMessage
     ${'true'}         | ${'dsc_denied'}                 | ${'accept the data sharing consent'}
     ${'true'}         | ${'verified_mode_unavailable'}  | ${'verified course mode is unavailable'}
+    ${'true'}         | ${''}                           | ${'unknown error'}
   `(
     'renders $failureReason alert with `enrollment_failed=$enrollmentFailed` and `failure_reason=$failureReason`',
     ({ enrollmentFailed, failureReason, expectedMessage }) => {
+      let mockedSearchString = `?enrollment_failed=${enrollmentFailed}`;
+      if (failureReason) {
+        mockedSearchString += `&failure_reason=${failureReason}`;
+      }
       useLocation.mockImplementation(() => ({
-        search: `?enrollment_failed=${enrollmentFailed}&failure_reason=${failureReason}`,
+        search: mockedSearchString,
       }));
 
       render(


### PR DESCRIPTION
In testing ENT-4564 on stage, I noticed that the only `failure_reason` that gets added to the `failure_url` is when the verified mode is unavailable. Ideally, we'd have a failure reason for `dsc_denied` as well so we can have messaging specific to that failure mode ([added via this PR](https://github.com/edx/edx-enterprise/pull/1349)). For broad failures, the `failure_reason` is nonexistent, so no error alert gets shown at all.

This PR adds a default error message to catch when an enrollment is failed, but has no explicit reason specified so an alert still appears to inform the learner that something went wrong.

Another PR will be written to add `dsc_denied` as a failure mode on the edx-enterprise side of things.