### PR TITLE
feat: added current dropdown functionality to show recommended courses

### DIFF
--- a/src/components/skills-quiz/CurrentJobDropdown.jsx
+++ b/src/components/skills-quiz/CurrentJobDropdown.jsx
@@ -14,7 +14,7 @@ const CurrentJobDropdown = () => {
       const filtersFromRefinements = () => (
         <FacetListRefinement
           key={attribute}
-          title={refinements[customAttribute] ? refinements[customAttribute] : title}
+          title={refinements[customAttribute]?.length > 0 ? refinements[customAttribute][0] : title}
           attribute={attribute}
           limit={300} // this is replicating the B2C search experience
           refinements={refinements}

--- a/src/components/skills-quiz/JobCardComponent.jsx
+++ b/src/components/skills-quiz/JobCardComponent.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Card } from '@edx/paragon';
+import Skeleton from 'react-loading-skeleton';
+import Truncate from 'react-truncate';
+import PropTypes from 'prop-types';
+
+const JobCardComponent = ({ jobs, isLoading }) => (
+  <>
+    {jobs?.map(job => (
+      <div
+        key={job.name}
+        className="search-job-card mb-3"
+        role="group"
+        aria-label={job.name}
+      >
+        <Card>
+          <Card.Body>
+            <Card.Title as="h5" className="card-title mb-3">
+              {isLoading ? (
+                <Skeleton count={1} data-testid="job-title-loading" />
+              ) : (
+                <Truncate lines={1} trimWhitespace>
+                  {job.name}
+                </Truncate>
+              )}
+            </Card.Title>
+            {isLoading ? (
+              <Skeleton duration={0} data-testid="job-content-loading" />
+            ) : (
+              <>
+                {job.job_postings && job.job_postings.length > 0 && (
+                  <div>
+                    <p className="text-muted m-0 medium-font">
+                      <span style={{ fontWeight: 500 }}>Median Salary:</span> {job.job_postings[0].median_salary}
+                    </p>
+                    <p className="text-muted m-0 medium-font">
+                      <span style={{ fontWeight: 500 }}>Job Postings:</span> {job.job_postings[0].unique_postings}
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
+          </Card.Body>
+        </Card>
+      </div>
+    ))}
+  </>
+);
+
+JobCardComponent.defaultProps = {
+  jobs: undefined,
+  isLoading: false,
+};
+
+JobCardComponent.propTypes = {
+  isLoading: PropTypes.bool,
+  jobs: PropTypes.arrayOf(PropTypes.shape()),
+};
+
+export default JobCardComponent;

--- a/src/components/skills-quiz/SearchCourseCard.jsx
+++ b/src/components/skills-quiz/SearchCourseCard.jsx
@@ -130,6 +130,7 @@ const SearchCourseCard = ({ index }) => {
             className="course-card-result mb-4"
             role="group"
             aria-label={course.title}
+            key={course.title}
           >
             { /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
             <Link to={isLoading ? '#' : linkToCourse(course, slug)}>

--- a/src/components/skills-quiz/SearchCurrentJobCard.jsx
+++ b/src/components/skills-quiz/SearchCurrentJobCard.jsx
@@ -2,25 +2,26 @@ import React, {
   useContext, useState, useEffect, useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
+
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { SkillsContext } from './SkillsContextProvider';
-import { SET_KEY_VALUE } from './data/constants';
 import JobCardComponent from './JobCardComponent';
+import { SET_KEY_VALUE } from './data/constants';
 
-const SearchJobCard = ({ index }) => {
+const SearchCurrentJobCard = ({ index }) => {
   const { refinements } = useContext(SearchContext);
-  const { name: jobs } = refinements;
+  const { current_job: currentJob } = refinements;
   const [isLoading, setIsLoading] = useState(true);
   const { dispatch, state } = useContext(SkillsContext);
-  const { interestedJobs } = state;
-  const jobsToFetch = useMemo(() => {
+  const { currentJobRole } = state;
+  const jobToFetch = useMemo(() => {
     const jobsArray = [];
-    if (jobs) {
-      jobs.forEach(job => jobsArray.push(`name:${job}`));
+    if (currentJob?.length > 0) {
+      jobsArray.push(`name:${currentJob[0]}`);
     }
     return jobsArray;
   },
-  [jobs]);
+  [currentJobRole]);
 
   useEffect(
     () => {
@@ -32,26 +33,25 @@ const SearchJobCard = ({ index }) => {
         setIsLoading(true);
         const { hits } = await index.search('', {
           facetFilters: [
-            jobsToFetch,
+            jobToFetch,
           ],
         });
         if (!fetch) { return; }
-        const jobHits = hits.length <= 3 ? hits : hits.slice(0, 3);
-        dispatch({ type: SET_KEY_VALUE, key: 'interestedJobs', value: jobHits });
+        dispatch({ type: SET_KEY_VALUE, key: 'currentJobRole', value: hits });
         setIsLoading(false);
       }
     },
-    [jobs],
+    [currentJob],
   );
 
   return (
     <div>
-      <JobCardComponent jobs={interestedJobs} isLoading={isLoading} />
+      <JobCardComponent jobs={currentJobRole} isLoading={isLoading} />
     </div>
   );
 };
 
-SearchJobCard.propTypes = {
+SearchCurrentJobCard.propTypes = {
   index: PropTypes.shape({
     appId: PropTypes.string,
     indexName: PropTypes.string,
@@ -59,4 +59,4 @@ SearchJobCard.propTypes = {
   }).isRequired,
 };
 
-export default SearchJobCard;
+export default SearchCurrentJobCard;

--- a/src/components/skills-quiz/SelectJobCard.jsx
+++ b/src/components/skills-quiz/SelectJobCard.jsx
@@ -2,12 +2,23 @@ import React, { useContext } from 'react';
 import { Card, Form } from '@edx/paragon';
 import { SkillsContext } from './SkillsContextProvider';
 import { SET_KEY_VALUE } from './data/constants';
+import { DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE } from './constants';
 
 const SelectJobCard = () => {
   const { dispatch, state } = useContext(SkillsContext);
-  const { interestedJobs, selectedJob } = state;
+  const {
+    interestedJobs, selectedJob, currentJobRole, goal,
+  } = state;
   const jobsCharactersCutOffLimit = 20;
-
+  let jobSelected;
+  let jobsCard;
+  if (goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && currentJobRole?.length > 0) {
+    jobSelected = currentJobRole[0].name;
+    jobsCard = currentJobRole;
+  } else {
+    jobSelected = selectedJob;
+    jobsCard = interestedJobs;
+  }
   return (
     <>
       <h4>Related jobs and skills</h4>
@@ -15,12 +26,12 @@ const SelectJobCard = () => {
         <Form.RadioSet
           name="selected-job"
           onChange={(e) => dispatch({ type: SET_KEY_VALUE, key: 'selectedJob', value: e.target.value })}
-          defaultValue={selectedJob}
+          defaultValue={jobSelected}
           isInline
           className="row"
         >
 
-          {interestedJobs?.map(job => (
+          {jobsCard?.map(job => (
             <div
               key={job.name}
               role="group"
@@ -36,7 +47,7 @@ const SelectJobCard = () => {
                     <Form.Radio value={job.name} />
                   </Card.Title>
                   <>
-                    {job.job_postings && job.job_postings.length > 0 && (
+                    {job.job_postings?.length > 0 && (
                       <div>
                         <p className="text-muted m-0 medium-font">
                           <span style={{ fontWeight: 500 }}>Median Salary:</span> {job.job_postings[0].median_salary}

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -15,6 +15,7 @@ import SearchJobDropdown from './SearchJobDropdown';
 import CurrentJobDropdown from './CurrentJobDropdown';
 import SkillsDropDown from './SkillsDropDown';
 import SearchJobCard from './SearchJobCard';
+import SearchCurrentJobCard from './SearchCurrentJobCard';
 import SearchCourseCard from './SearchCourseCard';
 import SelectJobCard from './SelectJobCard';
 import TagCloud from '../TagCloud';
@@ -40,7 +41,7 @@ const SkillsQuizStepper = () => {
   const { state, dispatch: skillsDispatch } = useContext(SkillsContext);
   const { selectedJob, goal } = state;
   const { refinements, dispatch } = useContext(SearchContext);
-  const { skill_names: skills, name: jobs } = refinements;
+  const { skill_names: skills, name: jobs, current_job: currentJob } = refinements;
   const { enterpriseConfig } = useContext(AppContext);
   const history = useHistory();
   const selectedSkillsAndJobSkills = useSelectedSkillsAndJobSkills();
@@ -68,7 +69,7 @@ const SkillsQuizStepper = () => {
 
   const flipToRecommendedCourses = () => {
     // show  courses if learner has selected skills or jobs.
-    if (skills?.length > 0 || (goal !== DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && (jobs?.length > 0))) {
+    if (goal !== DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && (jobs?.length > 0)) {
       // verify if selectedJob is still checked and within first 3 jobs else
       // set first job as selected by default to show courses.
       if (jobs?.length > 0 && ((selectedJob && !jobs?.includes(selectedJob)) || !selectedJob)) {
@@ -78,6 +79,13 @@ const SkillsQuizStepper = () => {
           value: jobs[0],
         });
       }
+      setCurrentStep(STEP2);
+    } else if (goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && currentJob?.length > 0) {
+      skillsDispatch({
+        type: SET_KEY_VALUE,
+        key: 'selectedJob',
+        value: currentJob[0],
+      });
       setCurrentStep(STEP2);
     }
   };
@@ -156,6 +164,8 @@ const SkillsQuizStepper = () => {
                   </InstantSearch>
                   { (goal !== DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && (jobs?.length > 0))
                     ? <SearchJobCard index={jobIndex} /> : null }
+                  { (goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && (currentJob?.length > 0))
+                    ? <SearchCurrentJobCard index={jobIndex} /> : null }
                 </div>
               </div>
             </Stepper.Step>
@@ -164,7 +174,8 @@ const SkillsQuizStepper = () => {
                 <h2>Review!</h2>
               </div>
               <div className="search-job-card mb-3">
-                {(goal !== DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && (jobs?.length > 0)) ? <SelectJobCard /> : null}
+                {(goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && currentJob?.length > 0)
+                || (goal !== DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && (jobs?.length > 0)) ? <SelectJobCard /> : null}
               </div>
               <div>
                 { (selectedJob || skills || goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE)

--- a/src/components/skills-quiz/data/hooks.js
+++ b/src/components/skills-quiz/data/hooks.js
@@ -5,24 +5,28 @@ import { DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE } from '../constants';
 
 export const useSelectedSkillsAndJobSkills = () => {
   const { state } = useContext(SkillsContext);
-  const { selectedJob, interestedJobs, goal } = state;
+  const {
+    selectedJob, interestedJobs, goal, currentJobRole,
+  } = state;
   const { refinements } = useContext(SearchContext);
   const { skill_names: skills } = refinements;
   const skillsFromSelectedJob = useMemo(
     () => {
       let skillsFromJob = [];
-      // if goal is to get better at current job, we should ignore the selectedJob value in SkillsContext
-      // we should only show courses based on skills that learner selected
-      if (selectedJob && goal !== DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE) {
+      if (selectedJob && goal !== DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && interestedJobs?.length > 0) {
         interestedJobs.forEach((job) => {
           if (job.name === selectedJob) {
             skillsFromJob = job.skills?.map(skill => skill.name);
           }
         });
       }
+      if (goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE && currentJobRole?.length > 0) {
+        // there can be only one current job.
+        skillsFromJob = currentJobRole[0].skills?.map(skill => skill.name);
+      }
       return skillsFromJob;
     },
-    [skills, interestedJobs, selectedJob, goal],
+    [skills, interestedJobs, selectedJob, goal, currentJobRole],
   );
   return skills ? skills.concat(skillsFromSelectedJob) : skillsFromSelectedJob;
 };


### PR DESCRIPTION
[ENT-4932](https://openedx.atlassian.net/browse/ENT-4932): 
Functionality added in this PR:
1- Learners have to select search job or the current job to see recommended courses. they can't see recommended courses only on the basis of skills.
2- Added key for course card
3- Fix for current job title as refinement is returning array not string
4- when the user selects current job with the goal type `I want to improve my current role` then show him the job card with the job details he selected. Also, allow him to move to the second page to see the recommended courses. 
4- Create a new component named `JobCardComponent` which will be used with both `SearchJobs` and `CurrentJob`

**Test Cases Failure:**
Test cases are failing due to COVERALLS api failure
https://status.coveralls.io/
<img width="1387" alt="Screenshot 2021-09-21 at 12 00 32 PM" src="https://user-images.githubusercontent.com/11922730/134125980-867a3ac6-9d50-484f-9bbb-9fb8842cdeb1.png">
.
