### PR TITLE
fix: show top 3 courses based on job-skills only

### DIFF
--- a/src/components/skills-quiz/SearchCourseCard.jsx
+++ b/src/components/skills-quiz/SearchCourseCard.jsx
@@ -66,7 +66,7 @@ const SearchCourseCard = ({ index }) => {
   const { refinements } = useContext(SearchContext);
   const { skill_names: skills } = refinements;
   const { selectedJob } = state;
-  const selectedSkillsAndJobSkills = useSelectedSkillsAndJobSkills();
+  const selectedSkillsAndJobSkills = useSelectedSkillsAndJobSkills({ getAllSkills: false });
   const skillsFacetFilter = useMemo(
     () => {
       if (selectedSkillsAndJobSkills) {

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -44,8 +44,7 @@ const SkillsQuizStepper = () => {
   const { skill_names: skills, name: jobs, current_job: currentJob } = refinements;
   const { enterpriseConfig } = useContext(AppContext);
   const history = useHistory();
-  const selectedSkillsAndJobSkills = useSelectedSkillsAndJobSkills();
-
+  const selectedSkillsAndJobSkills = useSelectedSkillsAndJobSkills({ getAllSkills: true });
   const getQueryParamString = () => {
     if (selectedSkillsAndJobSkills) {
       const queryParams = selectedSkillsAndJobSkills.map((skill) => `skill_names=${ fixedEncodeURIComponent(skill)}`);

--- a/src/components/skills-quiz/data/hooks.js
+++ b/src/components/skills-quiz/data/hooks.js
@@ -3,7 +3,7 @@ import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { SkillsContext } from '../SkillsContextProvider';
 import { DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE } from '../constants';
 
-export const useSelectedSkillsAndJobSkills = () => {
+export const useSelectedSkillsAndJobSkills = ({ getAllSkills }) => {
   const { state } = useContext(SkillsContext);
   const {
     selectedJob, interestedJobs, goal, currentJobRole,
@@ -26,7 +26,12 @@ export const useSelectedSkillsAndJobSkills = () => {
       }
       return skillsFromJob;
     },
-    [skills, interestedJobs, selectedJob, goal, currentJobRole],
+    [skills, interestedJobs, selectedJob, goal, currentJobRole, getAllSkills],
   );
-  return skills ? skills.concat(skillsFromSelectedJob) : skillsFromSelectedJob;
+  // Top 3 Recommended courses are shown based on job-skills only
+  // But on search page show courses based on job-skills and skills selected in skills dropdown as well
+  if (getAllSkills) {
+    return skills ? skills.concat(skillsFromSelectedJob) : skillsFromSelectedJob;
+  }
+  return skillsFromSelectedJob;
 };

--- a/src/components/skills-quiz/data/tests/hooks.test.jsx
+++ b/src/components/skills-quiz/data/tests/hooks.test.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import '@testing-library/jest-dom/extend-expect';
+import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
+import { useSelectedSkillsAndJobSkills } from '../hooks';
+import { SkillsContext } from '../../SkillsContextProvider';
+import { DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE, DROPDOWN_OPTION_GET_PROMOTED } from '../../constants';
+
+const SearchWrapper = (searchContext, initialSkillsState) => ({ children }) => (
+  <SearchContext.Provider value={searchContext}>
+    <SkillsContext.Provider value={initialSkillsState}>
+      {children}
+    </SkillsContext.Provider>
+  </SearchContext.Provider>
+);
+
+const skills = ['test-skill-1', 'test-skill-2'];
+const SELECTED_JOB_SKILL_NAME = 'test-skill-3';
+const CURRENT_JOB_SKILL_NAME = 'test-skill-4';
+const searchContext = {
+  refinements: { skill_names: skills },
+};
+
+const initialSkillsState = {
+  state: {
+    goal: DROPDOWN_OPTION_GET_PROMOTED,
+    selectedJob: 'job-1',
+    interestedJobs: [
+      {
+        name: 'job-1',
+        skills: [
+          {
+            name: SELECTED_JOB_SKILL_NAME,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe('useSelectedSkillsAndJobSkills hook', () => {
+  test('with getAllSkills true, returns learner selected skills and job-skills', () => {
+    const { result } = renderHook(() => useSelectedSkillsAndJobSkills({
+      getAllSkills: true,
+    }), { wrapper: SearchWrapper(searchContext, initialSkillsState) });
+
+    const skillsArray = result.current;
+    const expected = skills.concat(SELECTED_JOB_SKILL_NAME);
+    expect(skillsArray).toEqual(expected);
+  });
+
+  test('with getAllSkills false, returns job-skills only', () => {
+    const { result } = renderHook(() => useSelectedSkillsAndJobSkills({
+      getAllSkills: false,
+    }), { wrapper: SearchWrapper(searchContext, initialSkillsState) });
+
+    const skillsArray = result.current;
+    const expected = [SELECTED_JOB_SKILL_NAME];
+    expect(skillsArray).toEqual(expected);
+  });
+
+  test('when goal is "I want to improve at current role", returns currentJob skills', () => {
+    const skillsContextWithCurrentRole = {
+      state: {
+        goal: DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE,
+        selectedJob: 'job-1',
+        currentJobRole: [
+          {
+            skills: [
+              {
+                name: CURRENT_JOB_SKILL_NAME,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const { result } = renderHook(() => useSelectedSkillsAndJobSkills({
+      getAllSkills: false,
+    }), { wrapper: SearchWrapper(searchContext, skillsContextWithCurrentRole) });
+    const skillsArray = result.current;
+    const expected = [CURRENT_JOB_SKILL_NAME];
+    expect(skillsArray).toEqual(expected);
+  });
+});


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-4940

Top 3 courses should be shown based on the jobs that learner selected or their current job, but when the "See More Courses" button is clicked, it should show courses based on job-skills AND skills selected by learner in the skills dropdown. 