### PR TITLE
fix: style changes in job card components 

### DIFF
--- a/src/components/skills-quiz/JobCardComponent.jsx
+++ b/src/components/skills-quiz/JobCardComponent.jsx
@@ -3,6 +3,7 @@ import { Card } from '@edx/paragon';
 import Skeleton from 'react-loading-skeleton';
 import Truncate from 'react-truncate';
 import PropTypes from 'prop-types';
+import { formatStringAsNumber } from '../../utils/common';
 
 const JobCardComponent = ({ jobs, isLoading }) => (
   <>
@@ -15,7 +16,7 @@ const JobCardComponent = ({ jobs, isLoading }) => (
       >
         <Card>
           <Card.Body>
-            <Card.Title as="h5" className="card-title mb-3">
+            <Card.Title as="h4" className="card-title mb-3">
               {isLoading ? (
                 <Skeleton count={1} data-testid="job-title-loading" />
               ) : (
@@ -28,13 +29,15 @@ const JobCardComponent = ({ jobs, isLoading }) => (
               <Skeleton duration={0} data-testid="job-content-loading" />
             ) : (
               <>
-                {job.job_postings && job.job_postings.length > 0 && (
-                  <div>
-                    <p className="text-muted m-0 medium-font">
-                      <span style={{ fontWeight: 500 }}>Median Salary:</span> {job.job_postings[0].median_salary}
+                {job.job_postings?.length > 0 && (
+                  <div className="text-gray-700">
+                    <p className="m-0 medium-font">
+                      <span style={{ fontWeight: 700 }}>Median Salary: </span>
+                      ${formatStringAsNumber(job.job_postings[0].median_salary)}
                     </p>
-                    <p className="text-muted m-0 medium-font">
-                      <span style={{ fontWeight: 500 }}>Job Postings:</span> {job.job_postings[0].unique_postings}
+                    <p className="m-0 medium-font">
+                      <span style={{ fontWeight: 700 }}>Job Postings: </span>
+                      {formatStringAsNumber(job.job_postings[0].unique_postings)}
                     </p>
                   </div>
                 )}

--- a/src/components/skills-quiz/SelectJobCard.jsx
+++ b/src/components/skills-quiz/SelectJobCard.jsx
@@ -3,6 +3,7 @@ import { Card, Form } from '@edx/paragon';
 import { SkillsContext } from './SkillsContextProvider';
 import { SET_KEY_VALUE } from './data/constants';
 import { DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE } from './constants';
+import { formatStringAsNumber } from '../../utils/common';
 
 const SelectJobCard = () => {
   const { dispatch, state } = useContext(SkillsContext);
@@ -21,7 +22,7 @@ const SelectJobCard = () => {
   }
   return (
     <>
-      <h4>Related jobs and skills</h4>
+      <h3>Related jobs and skills</h3>
       <Form.Group>
         <Form.RadioSet
           name="selected-job"
@@ -39,7 +40,7 @@ const SelectJobCard = () => {
             >
               <Card className={`${selectedJob === job.name ? 'border border-dark' : null}`}>
                 <Card.Body>
-                  <Card.Title as="h5" className="card-title mb-1">
+                  <Card.Title as="h4" className="card-title mb-2">
                     <>
                       {job.name.length > jobsCharactersCutOffLimit
                         ? `${job.name.substring(0, jobsCharactersCutOffLimit)}...` : job.name}
@@ -48,12 +49,14 @@ const SelectJobCard = () => {
                   </Card.Title>
                   <>
                     {job.job_postings?.length > 0 && (
-                      <div>
-                        <p className="text-muted m-0 medium-font">
-                          <span style={{ fontWeight: 500 }}>Median Salary:</span> {job.job_postings[0].median_salary}
+                      <div className="text-gray-700">
+                        <p className="m-0 medium-font">
+                          <span style={{ fontWeight: 700 }}>Median Salary: </span>
+                          ${formatStringAsNumber(job.job_postings[0].median_salary)}
                         </p>
-                        <p className="text-muted m-0 medium-font">
-                          <span style={{ fontWeight: 500 }}>Job Postings:</span> {job.job_postings[0].unique_postings}
+                        <p className="m-0 medium-font">
+                          <span style={{ fontWeight: 700 }}>Job Postings: </span>
+                          {formatStringAsNumber(job.job_postings[0].unique_postings)}
                         </p>
                       </div>
                     )}

--- a/src/components/skills-quiz/tests/SearchJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchJobCard.test.jsx
@@ -19,8 +19,10 @@ jest.mock('react-loading-skeleton', () => ({
 
 const TEST_JOB_KEY = 'test-job-key';
 const TEST_JOB_TITLE = 'Test Job Title';
-const TEST_MEDIAN_SALARY = '$10,0000';
+const TEST_MEDIAN_SALARY = '100000';
 const TEST_JOB_POSTINGS = '4321';
+const TRANSFORMED_MEDIAN_SALARY = '$100,000';
+const TRANSFORMED_JOB_POSTINGS = '4,321';
 
 const hitObject = {
   hits: [
@@ -48,7 +50,7 @@ describe('<SearchJobCard />', () => {
       renderWithSearchContext(<SearchJobCard index={testIndex} />);
     });
     expect(await screen.getByText(TEST_JOB_TITLE)).toBeInTheDocument();
-    expect(await screen.getByText(TEST_MEDIAN_SALARY)).toBeInTheDocument();
-    expect(await screen.getByText(TEST_JOB_POSTINGS)).toBeInTheDocument();
+    expect(await screen.getByText(TRANSFORMED_MEDIAN_SALARY)).toBeInTheDocument();
+    expect(await screen.getByText(TRANSFORMED_JOB_POSTINGS)).toBeInTheDocument();
   });
 });

--- a/src/components/skills-quiz/tests/SelectJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SelectJobCard.test.jsx
@@ -29,6 +29,13 @@ const SelectJobCardWithContext = ({
 );
 /* eslint-enable react/prop-types */
 
+const TEST_MEDIAN_SALARY = '100000';
+const TEST_MEDIAN_SALARY_2 = '250000';
+const TEST_UNIQUE_POSTINGS = '45';
+const TEST_UNIQUE_POSTINGS_2 = '500';
+const TRANSFORMED_MEDIAN_SALARY = '$100,000';
+const TRANSFORMED_MEDIAN_SALARY_2 = '$250,000';
+
 describe('<SelectJobCard />', () => {
   test('renders job card', () => {
     const initialJobCardState = {
@@ -37,8 +44,8 @@ describe('<SelectJobCard />', () => {
         objectID: 'TEST_JOB_KEY',
         job_postings: [
           {
-            median_salary: '$10000',
-            unique_postings: '45',
+            median_salary: TEST_MEDIAN_SALARY,
+            unique_postings: TEST_UNIQUE_POSTINGS,
           },
         ],
 
@@ -52,9 +59,8 @@ describe('<SelectJobCard />', () => {
       />,
     );
     expect(screen.queryByText(initialJobCardState.interestedJobs[0].name)).toBeInTheDocument();
-    expect(screen.queryByText(initialJobCardState.interestedJobs[0].job_postings[0].median_salary)).toBeInTheDocument();
-    expect(screen.queryByText(initialJobCardState.interestedJobs[0].job_postings[0].unique_postings))
-      .toBeInTheDocument();
+    expect(screen.queryByText(TRANSFORMED_MEDIAN_SALARY)).toBeInTheDocument();
+    expect(screen.queryByText(TEST_UNIQUE_POSTINGS)).toBeInTheDocument();
   });
 
   test('renders multiple job card', () => {
@@ -64,8 +70,8 @@ describe('<SelectJobCard />', () => {
         objectID: '11',
         job_postings: [
           {
-            median_salary: '$10000',
-            unique_postings: '45',
+            median_salary: TEST_MEDIAN_SALARY,
+            unique_postings: TEST_UNIQUE_POSTINGS,
           },
         ],
 
@@ -75,8 +81,8 @@ describe('<SelectJobCard />', () => {
         objectID: '12',
         job_postings: [
           {
-            median_salary: '$20000',
-            unique_postings: '35',
+            median_salary: TEST_MEDIAN_SALARY_2,
+            unique_postings: TEST_UNIQUE_POSTINGS_2,
           },
         ],
 
@@ -90,13 +96,11 @@ describe('<SelectJobCard />', () => {
       />,
     );
     expect(screen.queryByText(initialJobCardState.interestedJobs[0].name)).toBeInTheDocument();
-    expect(screen.queryByText(initialJobCardState.interestedJobs[0].job_postings[0].median_salary)).toBeInTheDocument();
-    expect(screen.queryByText(initialJobCardState.interestedJobs[0].job_postings[0].unique_postings))
-      .toBeInTheDocument();
+    expect(screen.queryByText(TRANSFORMED_MEDIAN_SALARY)).toBeInTheDocument();
+    expect(screen.queryByText(TEST_UNIQUE_POSTINGS)).toBeInTheDocument();
     expect(screen.queryByText(initialJobCardState.interestedJobs[1].name)).toBeInTheDocument();
-    expect(screen.queryByText(initialJobCardState.interestedJobs[1].job_postings[0].median_salary)).toBeInTheDocument();
-    expect(screen.queryByText(initialJobCardState.interestedJobs[1].job_postings[0].unique_postings))
-      .toBeInTheDocument();
+    expect(screen.queryByText(TRANSFORMED_MEDIAN_SALARY_2)).toBeInTheDocument();
+    expect(screen.queryByText(TEST_UNIQUE_POSTINGS_2)).toBeInTheDocument();
   });
 
   test('renders no job card', () => {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -67,3 +67,9 @@ export const loginRefresh = async () => {
 };
 
 export const fixedEncodeURIComponent = (str) => encodeURIComponent(str).replace(/[!()*]/g, (c) => `%${ c.charCodeAt(0).toString(16)}`);
+
+export const formatStringAsNumber = (str, radix = 10) => {
+  // converts a string into a number and format it with separated commas
+  const num = parseInt(str, radix);
+  return num.toLocaleString();
+};


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-4926

Changes: 

- Bolded Median Salary and Job Postings text for Search and Select job cards
- Text color for non-head text is set to "text-gray-700"
- Formatted median salary with separated commas and $ symbol
- Made the header sizes for "Recommended Courses" and "Related jobs and skills" consistent, set to "h3"
- Fixed failing test cases

<img width="396" alt="Screenshot 2021-09-21 at 3 40 14 PM" src="https://user-images.githubusercontent.com/55431213/134164642-a9724e2c-9f3d-43fb-bb67-8b933a2daefe.png">

<img width="746" alt="Screenshot 2021-09-21 at 3 40 52 PM" src="https://user-images.githubusercontent.com/55431213/134164675-69c73dc8-b9d0-4220-8276-d0ff39e9a689.png">

