### PR TITLE
feat: ENT-4865: Filter out programs from search page.

### DIFF
--- a/src/components/course/tests/testUtils.js
+++ b/src/components/course/tests/testUtils.js
@@ -41,8 +41,6 @@ export const generateRandomString = (MAX_LENGTH) => {
   // there might be a chance that we get a string larger than MX_LENGTH based on the random integer value,
   // to ensure the length is equal to MAX_LENGTH passed, we slice the string
   let resStr = result.join(' ');
-  if (resStr.length > MAX_LENGTH) {
-    resStr = resStr.substr(0, MAX_LENGTH);
-  }
+  resStr = (resStr.length > MAX_LENGTH) ? resStr.substr(0, MAX_LENGTH) : resStr;
   return resStr;
 };

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -20,9 +20,12 @@ export const useDefaultSearchFilters = ({
 
   const filters = useMemo(
     () => {
+      // Do not show programs in the search result.
+      const defaultFilter = 'NOT content_type:program AND';
+
       // show all enterprise catalogs
       if (refinements[SHOW_ALL_NAME]) {
-        return `enterprise_customer_uuids:${enterpriseConfig.uuid}`;
+        return `${defaultFilter} enterprise_customer_uuids:${enterpriseConfig.uuid}`;
       }
 
       // Filter catalogs by offer catalogs (if any) and/or by the subscription plan catalog associated
@@ -35,11 +38,11 @@ export const useDefaultSearchFilters = ({
         catalogs.push(subscriptionPlan.enterpriseCatalogUuid);
       }
       if (catalogs.length > 0) {
-        return getCatalogString(catalogs);
+        return `${defaultFilter} ${getCatalogString(catalogs)}`;
       }
 
       // If learner has no subsidy available to them, show all enterprise catalogs
-      return `enterprise_customer_uuids:${enterpriseConfig.uuid}`;
+      return `${defaultFilter} enterprise_customer_uuids:${enterpriseConfig.uuid}`;
     },
     [
       enterpriseConfig,

--- a/src/components/search/data/tests/hooks.test.jsx
+++ b/src/components/search/data/tests/hooks.test.jsx
@@ -38,7 +38,7 @@ describe('useDefaultSearchFilters hook', () => {
       }), { wrapper: SearchData });
       const { filters } = result.current;
       expect(filters).toBeDefined();
-      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+      expect(filters).toEqual(`NOT content_type:program AND enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
     });
 
     test('with valid subscription: returns subscription catalog uuid as filter', () => {
@@ -47,7 +47,7 @@ describe('useDefaultSearchFilters hook', () => {
       }), { wrapper: SearchData });
       const { filters } = result.current;
       expect(filters).toBeDefined();
-      expect(filters).toEqual(`enterprise_catalog_uuids:${TEST_SUBSCRIPTION_CATALOG_UUID}`);
+      expect(filters).toEqual(`NOT content_type:program AND enterprise_catalog_uuids:${TEST_SUBSCRIPTION_CATALOG_UUID}`);
     });
 
     test('with invalid subscription: returns enterprise customer uuid as a filter', () => {
@@ -58,7 +58,7 @@ describe('useDefaultSearchFilters hook', () => {
       }), { wrapper: SearchData });
       const { filters } = result.current;
       expect(filters).toBeDefined();
-      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+      expect(filters).toEqual(`NOT content_type:program AND enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
     });
     test('with valid subscription and showAllCatalogs: returns subscription and all enterprise catalogs', () => {
       const { result } = renderHook(() => useDefaultSearchFilters({
@@ -68,7 +68,7 @@ describe('useDefaultSearchFilters hook', () => {
       }), { wrapper: SearchWrapper({ ...refinementsShowAll }) });
 
       const { filters } = result.current;
-      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+      expect(filters).toEqual(`NOT content_type:program AND enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
     });
   });
   describe('with catalogs', () => {
@@ -82,7 +82,7 @@ describe('useDefaultSearchFilters hook', () => {
       }), { wrapper: SearchData });
       const { filters } = result.current;
       expect(filters).toBeDefined();
-      const expectedFilters = `${getCatalogString(offerCatalogs)} OR enterprise_catalog_uuids:${TEST_SUBSCRIPTION_CATALOG_UUID}`;
+      const expectedFilters = `NOT content_type:program AND ${getCatalogString(offerCatalogs)} OR enterprise_catalog_uuids:${TEST_SUBSCRIPTION_CATALOG_UUID}`;
       expect(filters).toEqual(expectedFilters);
     });
     test('with invalid subscription: returns offer catalogs', () => {
@@ -95,7 +95,7 @@ describe('useDefaultSearchFilters hook', () => {
       const { filters } = result.current;
       expect(filters).toBeDefined();
       expect(filters)
-        .toEqual(getCatalogString(offerCatalogs));
+        .toEqual(`NOT content_type:program AND ${getCatalogString(offerCatalogs)}`);
     });
     test('no subscription: returns only offers', () => {
       const { result } = renderHook(() => useDefaultSearchFilters({
@@ -105,7 +105,7 @@ describe('useDefaultSearchFilters hook', () => {
       }), { wrapper: SearchData });
       const { filters } = result.current;
       expect(filters).toBeDefined();
-      expect(filters).toEqual(getCatalogString(offerCatalogs));
+      expect(filters).toEqual(`NOT content_type:program AND ${getCatalogString(offerCatalogs)}`);
     });
     test('with showAllCatalogs: returns all enterprise catalgos', () => {
       const { result } = renderHook(() => useDefaultSearchFilters({
@@ -114,7 +114,7 @@ describe('useDefaultSearchFilters hook', () => {
         offerCatalogs,
       }), { wrapper: SearchWrapper({ ...refinementsShowAll }) });
       const { filters } = result.current;
-      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+      expect(filters).toEqual(`NOT content_type:program AND enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
     });
     test('with valid subscription and show all: returns all enterprise catalogs', () => {
       const { result } = renderHook(() => useDefaultSearchFilters({
@@ -124,7 +124,7 @@ describe('useDefaultSearchFilters hook', () => {
         offerCatalogs,
       }), { wrapper: SearchWrapper({ ...refinementsShowAll }) });
       const { filters } = result.current;
-      expect(filters).toEqual(`enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
+      expect(filters).toEqual(`NOT content_type:program AND enterprise_customer_uuids:${TEST_ENTERPRISE_UUID}`);
     });
   });
 });


### PR DESCRIPTION
Description: This PR removes Algolia objects with contenttype:program from the search results. This change will be removed once Program cards and Program pages are available in the learner portal via ENT-4858

Jira: https://openedx.atlassian.net/browse/ENT-4865