### PR TITLE
fix: reduce calls to Algolia from skill quiz

### DIFF
--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -31,12 +31,18 @@ import { checkValidGoalAndJobSelected } from '../utils/skills-quiz';
 
 const SkillsQuizStepper = () => {
   const config = getConfig();
-  const searchClient = algoliasearch(
-    config.ALGOLIA_APP_ID,
-    config.ALGOLIA_SEARCH_API_KEY,
+  const [searchClient, courseIndex, jobIndex] = useMemo(
+    () => {
+      const client = algoliasearch(
+        config.ALGOLIA_APP_ID,
+        config.ALGOLIA_SEARCH_API_KEY,
+      );
+      const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
+      const jIndex = client.initIndex(config.ALGOLIA_INDEX_NAME_JOBS);
+      return [client, cIndex, jIndex];
+    },
+    [], // only initialized once
   );
-  const courseIndex = searchClient.initIndex(config.ALGOLIA_INDEX_NAME);
-  const jobIndex = searchClient.initIndex(config.ALGOLIA_INDEX_NAME_JOBS);
   const [currentStep, setCurrentStep] = useState(STEP1);
 
   const { state, dispatch: skillsDispatch } = useContext(SkillsContext);
@@ -71,7 +77,7 @@ const SkillsQuizStepper = () => {
 
   const selectedSkills = useMemo(
     () => skills?.map(skill => ({ title: skill, metadata: { title: skill } })) || [],
-    [JSON.stringify(refinements)],
+    [skills],
   );
 
   const flipToRecommendedCourses = () => {


### PR DESCRIPTION
**Issue**: Duplicate calls were being made to Algolia from the first step of Skills Quiz page.

**Cause**: The reason was that the search client was initialized inside the Stepper component which was re-initializing on every render and thus losing already cached search data. 

**Solution**: Use React hook useMemo() to initialize the client only once on the first render only which significantly reduced the calls to Algolia. 

**JIRA**: https://openedx.atlassian.net/browse/ENT-4937