### PR TITLE
fix: Remove links to `/search` if customer has search disabled.

### DIFF
--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -42,7 +42,7 @@ export default function CourseHeader() {
       <Container size="lg">
         <Row className="py-4">
           <Col xs={12} lg={7}>
-            {primarySubject && (
+            {primarySubject && !enterpriseConfig.disableSearch && (
               <div className="small">
                 <Breadcrumb
                   links={[

--- a/src/components/course/tests/CourseHeader.test.jsx
+++ b/src/components/course/tests/CourseHeader.test.jsx
@@ -94,6 +94,18 @@ describe('<CourseHeader />', () => {
     expect(screen.queryAllByText(initialCourseState.course.title)[0]).toBeInTheDocument();
   });
 
+  test('does not render breadcrumb when search is disabled for customer', () => {
+    render(
+      <CourseHeaderWithContext
+        initialAppState={{ enterpriseConfig: { disableSearch: true } }}
+        initialCourseState={initialCourseState}
+        initialUserSubsidyState={initialUserSubsidyState}
+      />,
+    );
+    expect(screen.queryByText('Find a Course')).toBeFalsy();
+    expect(screen.queryAllByText(initialCourseState.course.title)[0]).toBeInTheDocument();
+  });
+
   test('renders course title and short description', () => {
     render(
       <CourseHeaderWithContext

--- a/src/components/dashboard/main-content/DashboardMainContent.jsx
+++ b/src/components/dashboard/main-content/DashboardMainContent.jsx
@@ -6,25 +6,37 @@ import { Button } from '@edx/paragon';
 import { CourseEnrollments } from './course-enrollments';
 
 const DashboardMainContent = () => {
-  const { enterpriseConfig: { name, slug } } = useContext(AppContext);
+  const { enterpriseConfig: { name, slug, disableSearch } } = useContext(AppContext);
 
   return (
     <CourseEnrollments>
       {/* The children below will only be rendered if there are no course runs. */}
-      <h2>Find a Course</h2>
-      <p>
-        You are not enrolled in any courses sponsored by {name}.
-        To start taking a course, browse the catalog below.
-      </p>
-      <p>
-        <Button
-          as={Link}
-          to={`/${slug}/search`}
-          className="btn-brand-primary"
-        >
-          Find a course
-        </Button>
-      </p>
+      {disableSearch ? (
+        <>
+          <h2>Get Started Learning</h2>
+          <p>
+            You are not enrolled in any courses sponsored by {name}.
+            Reach out to your administrator to begin learning with edX!
+          </p>
+        </>
+      ) : (
+        <>
+          <h2>Find a Course</h2>
+          <p>
+            You are not enrolled in any courses sponsored by {name}.
+            To start taking a course, browse the catalog below.
+          </p>
+          <p>
+            <Button
+              as={Link}
+              to={`/${slug}/search`}
+              className="btn-brand-primary"
+            >
+              Find a course
+            </Button>
+          </p>
+        </>
+      )}
     </CourseEnrollments>
   );
 };

--- a/src/components/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/dashboard/sidebar/DashboardSidebar.jsx
@@ -20,6 +20,7 @@ const DashboardSidebar = () => {
     enterpriseConfig: {
       contactEmail,
       slug,
+      disableSearch,
     },
   } = useContext(AppContext);
   const {
@@ -68,12 +69,14 @@ const DashboardSidebar = () => {
               className="mb-3"
             />
           )}
-          <Link
-            to={`/${slug}/search`}
-            className={classNames('btn btn-outline-primary btn-block', { disabled: !hasAccessToPortal })}
-          >
-            {CATALOG_ACCESS_CARD_BUTTON_TEXT}
-          </Link>
+          {!disableSearch && (
+            <Link
+              to={`/${slug}/search`}
+              className={classNames('btn btn-outline-primary btn-block', { disabled: !hasAccessToPortal })}
+            >
+              {CATALOG_ACCESS_CARD_BUTTON_TEXT}
+            </Link>
+          )}
         </SidebarCard>
       )}
       <SidebarBlock

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -130,6 +130,18 @@ describe('<DashboardSidebar />', () => {
     const catalogAccessButton = screen.queryByText(CATALOG_ACCESS_CARD_BUTTON_TEXT);
     expect(catalogAccessButton).toBeFalsy();
   });
+  test('Find a course button is not rendered when user has subsidy but customer has search disabled', () => {
+    renderWithRouter(
+      <DashboardSidebarContext
+        initialAppState={{ enterpriseConfig: { disableSearch: true } }}
+        initialUserSubsidyState={userSubsidyStateWithSubscription}
+      >
+        <DashboardSidebar />
+      </DashboardSidebarContext>,
+    );
+    const catalogAccessButton = screen.queryByText(CATALOG_ACCESS_CARD_BUTTON_TEXT);
+    expect(catalogAccessButton).toBeFalsy();
+  });
   test('Need help sidebar block is always rendered', () => {
     renderWithRouter(
       <DashboardSidebarContext

--- a/src/components/dashboard/tests/Dashboard.test.jsx
+++ b/src/components/dashboard/tests/Dashboard.test.jsx
@@ -35,6 +35,7 @@ const defaultAppState = {
   enterpriseConfig: {
     name: 'BearsRUs',
     uuid: 'BearsRUs',
+    disableSearch: false,
   },
   config: {
     LMS_BASE_URL: process.env.LMS_BASE_URL,
@@ -162,6 +163,32 @@ describe('<Dashboard />', () => {
       <DashboardWithContext />,
     );
     expect(screen.getByTestId('sidebar')).toBeTruthy();
+  });
+
+  it('renders Find a Course when search is enabled for the customer', () => {
+    renderWithRouter(
+      <DashboardWithContext />,
+    );
+    expect(screen.queryByText('Find a Course')).toBeTruthy();
+  });
+
+  it('does not render Find a Course when search is disabled for the customer', () => {
+    const appState = {
+      enterpriseConfig: {
+        name: 'BearsRUs',
+        uuid: 'BearsRUs',
+        disableSearch: true,
+      },
+      config: {
+        LMS_BASE_URL: process.env.LMS_BASE_URL,
+      },
+    };
+    renderWithRouter(
+      <DashboardWithContext
+        initialAppState={appState}
+      />,
+    );
+    expect(screen.queryByText('Find a Course')).toBeFalsy();
   });
 
   describe('SubscriptionExpirationModal', () => {


### PR DESCRIPTION
Don't show a "Find a course" button if the enterprise has search disabled; adjust in following places:
1. Dashboard main content
2. Dashboard sidebar
3. Course header breadcrumb.

https://openedx.atlassian.net/browse/ENT-5101

Dashboard for an enterprise with search disabled now:
![image](https://user-images.githubusercontent.com/2307986/140068481-9a189414-a7ff-45c9-8238-a8faf4401701.png)

Course page before:
![image](https://user-images.githubusercontent.com/2307986/140073810-04740ec3-c395-4aae-aa7c-43db6970c75b.png)

Course page after this change:
![image](https://user-images.githubusercontent.com/2307986/140073914-16f3d6d2-374a-4d79-9986-9a77928e47aa.png)

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
