### PR TITLE
style: added image style changes on skills quiz page

### DIFF
--- a/src/components/skills-quiz/styles/SkillsQuizDropdowns.scss
+++ b/src/components/skills-quiz/styles/SkillsQuizDropdowns.scss
@@ -14,8 +14,10 @@
 }
 
 .side-image {
-  clip-path: polygon(25% 0%, 100% 0%, 75% 100%, 0% 100%);
-  margin-top: 42px;
-  height: 480px;
+  clip-path: polygon(19% 0, 100% 0, 78% 100%, 0 100%);
+  margin-top: 20px;
+  height: 585px;
   width: 450px;
+  object-fit: cover;
+  object-position: right top;
 }


### PR DESCRIPTION
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

<img width="1680" alt="Screenshot 2021-11-16 at 7 06 04 PM" src="https://user-images.githubusercontent.com/11922730/142001202-fdecac36-29d5-47c1-ae06-e895016d79c2.png">

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
