### PR TITLE
fix: center align course result cards and job cards

### DIFF
--- a/src/components/skills-quiz/SearchCourseCard.jsx
+++ b/src/components/skills-quiz/SearchCourseCard.jsx
@@ -132,7 +132,7 @@ const SearchCourseCard = ({ index }) => {
   );
 
   return (
-    <div>
+    <div style={{ paddingLeft: '10%' }}>
       {(hitCount > 0) ? <h3 className="mt-2 mb-2"> Recommended Courses </h3> : null}
       <div className="course-results">
         {(hitCount > 0) && courses.map(course => (

--- a/src/components/skills-quiz/SelectJobCard.jsx
+++ b/src/components/skills-quiz/SelectJobCard.jsx
@@ -23,7 +23,7 @@ const SelectJobCard = () => {
     jobsCard = interestedJobs;
   }
   return (
-    <>
+    <div style={{ paddingLeft: '10%' }}>
       <h3>Related jobs and skills</h3>
       <Form.Group>
         <Form.RadioSet
@@ -40,7 +40,7 @@ const SelectJobCard = () => {
               role="group"
               aria-label={job.name}
             >
-              <Card className={`${selectedJob === job.name ? 'border border-dark' : null}`}>
+              <Card className={`${selectedJob === job.name ? 'border border-dark' : null} mt-2 ml-2`}>
                 <Card.Body>
                   <Card.Title as="h4" className="card-title mb-2">
                     <>
@@ -69,7 +69,7 @@ const SelectJobCard = () => {
           ))}
         </Form.RadioSet>
       </Form.Group>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
# For all changes
Before
<img width="1440" alt="Screen Shot 2021-11-17 at 6 00 52 AM" src="https://user-images.githubusercontent.com/49611774/142435183-4f75bce0-defc-490b-b42c-b3a661787dc6.png">
Now
<img width="1440" alt="Screenshot 2021-11-18 at 7 22 04 PM" src="https://user-images.githubusercontent.com/49611774/142434612-2ee01b24-4de1-49dc-9a01-eb3ff673969a.png">

- [x ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x ] Ensure to attach screenshots
- [x ] Ensure to have UX team confirm screenshots
