### PR TITLE
feat: hide course start date when course isnt instructor led

### DIFF
--- a/src/components/program/ProgramCourses.jsx
+++ b/src/components/program/ProgramCourses.jsx
@@ -57,7 +57,7 @@ const ProgramCourses = () => {
                     && (
                       <div className="course-card-result mb-2">
                         <FontAwesomeIcon icon={faCalendarAlt} className="fa-calendar-alt mr-2" />
-                        {courseRun && <span className="font-weight-bold">Starts {moment(courseRun.start).format(DATE_FORMAT)}</span>}
+                        <span className="font-weight-bold">Starts {moment(courseRun.start).format(DATE_FORMAT)}</span>
                       </div>
                     )
                   }

--- a/src/components/program/ProgramCourses.jsx
+++ b/src/components/program/ProgramCourses.jsx
@@ -13,6 +13,8 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useParams } from 'react-router-dom';
 import { ProgramContext } from './ProgramContextProvider';
 
+import { PROGRAM_PACING_MAP } from './data/constants';
+
 const DATE_FORMAT = 'MMM D, YYYY';
 
 const getCourseRun = course => (
@@ -50,10 +52,16 @@ const ProgramCourses = () => {
                 </Collapsible.Trigger>
 
                 <Collapsible.Body className="collapsible-body mt-3 ml-4.5">
-                  <div className="course-card-result mb-2">
-                    <FontAwesomeIcon icon={faCalendarAlt} className="fa-calendar-alt mr-2" />
-                    {courseRun && <span className="font-weight-bold">Starts {moment(courseRun.start).format(DATE_FORMAT)}</span>}
-                  </div>
+                  {
+                    (courseRun?.pacingType === PROGRAM_PACING_MAP.INSTRUCTOR_PACED && courseRun.start)
+                    && (
+                      <div className="course-card-result mb-2">
+                        <FontAwesomeIcon icon={faCalendarAlt} className="fa-calendar-alt mr-2" />
+                        {courseRun && <span className="font-weight-bold">Starts {moment(courseRun.start).format(DATE_FORMAT)}</span>}
+                      </div>
+                    )
+                  }
+
                   {course.shortDescription && (
                     <div
                       className="font-weight-normal mb-4"

--- a/src/components/program/tests/ProgramCourses.test.jsx
+++ b/src/components/program/tests/ProgramCourses.test.jsx
@@ -61,6 +61,7 @@ describe('<ProgramCourses />', () => {
               title: 'Test Course Run Title',
               start: '2013-02-05T05:00:00Z',
               shortDescription: 'Test course description',
+              pacingType: 'instructor_paced',
             },
           ],
           enterpriseHasCourse: true,
@@ -137,5 +138,33 @@ describe('<ProgramCourses />', () => {
     expect(screen.queryByText('View the course')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Test Course Title'));
     expect(screen.getByText("This course is not included in your organization's catalog.")).toBeInTheDocument();
+  });
+
+  test('renders start date when courses are instructor led', () => {
+    render(
+      <ProgramCoursestWithContext
+        initialAppState={initialAppState}
+        initialProgramState={initialProgramState}
+        initialUserSubsidyState={initialUserSubsidyState}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Test Course Title'));
+    expect(screen.queryByText('Starts Feb 5, 2013')).toBeInTheDocument();
+  });
+
+  test('does not renders start date when courses are self paced', () => {
+    const newInitialProgramState = { ...initialProgramState };
+    newInitialProgramState.program.courses[0].courseRuns[0].pacingType = 'self_paced';
+    render(
+      <ProgramCoursestWithContext
+        initialAppState={initialAppState}
+        initialProgramState={initialProgramState}
+        initialUserSubsidyState={initialUserSubsidyState}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Test Course Title'));
+    expect(screen.queryByText('Starts Feb 5, 2013')).not.toBeInTheDocument();
   });
 });

--- a/src/components/program/tests/ProgramCourses.test.jsx
+++ b/src/components/program/tests/ProgramCourses.test.jsx
@@ -159,12 +159,33 @@ describe('<ProgramCourses />', () => {
     render(
       <ProgramCoursestWithContext
         initialAppState={initialAppState}
-        initialProgramState={initialProgramState}
+        initialProgramState={newInitialProgramState}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
 
     fireEvent.click(screen.getByText('Test Course Title'));
     expect(screen.queryByText('Starts Feb 5, 2013')).not.toBeInTheDocument();
+  });
+
+  test('renders latest course run', () => {
+    const newInitialProgramState = { ...initialProgramState };
+    const secondCourseRun = {
+      title: 'Test Course Run Title',
+      start: '2014-02-05T05:00:00Z',
+      shortDescription: 'Test course description',
+      pacingType: 'instructor_paced',
+    };
+    newInitialProgramState.program.courses[0].courseRuns.push(secondCourseRun);
+    render(
+      <ProgramCoursestWithContext
+        initialAppState={initialAppState}
+        initialProgramState={newInitialProgramState}
+        initialUserSubsidyState={initialUserSubsidyState}
+      />,
+    );
+    fireEvent.click(screen.getByText('Test Course Title'));
+    expect(screen.queryByText('Starts Feb 5, 2013')).not.toBeInTheDocument();
+    expect(screen.queryByText('Starts Feb 5, 2014')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# For all changes
when course is self paced
<img width="1435" alt="Screenshot 2021-12-09 at 5 20 17 PM" src="https://user-images.githubusercontent.com/49611774/145412268-61f79a80-5238-4f11-b474-d72b55c8373a.png">

When course is instructor led
<img width="1436" alt="Screenshot 2021-12-09 at 5 21 13 PM" src="https://user-images.githubusercontent.com/49611774/145412389-b41cdecf-a442-4aa0-b382-f33bec629564.png">


- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
